### PR TITLE
Update UploadResultJson.cs

### DIFF
--- a/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/Media/UploadResultJson.cs
+++ b/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/Media/UploadResultJson.cs
@@ -13,6 +13,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
     {
        public UploadMediaFileType type { get; set; }
        public string media_id { get; set; }
+       public string thumb_media_id { get; set; } // 上传缩略图返回的meidia_id参数.
        public long created_at { get; set; }
     }
 }


### PR DESCRIPTION
上传缩略图时返回的是 thumb_media_id而不是meidia_id
测试页面：
https://mp.weixin.qq.com/debug/cgi-bin/apiinfo?t=index&type=%E5%9F%BA%E7%A1%80%E6%94%AF%E6%8C%81&form=%E4%B8%8B%E8%BD%BD%E5%A4%9A%E5%AA%92%E4%BD%93%E6%96%87%E4%BB%B6%E6%8E%A5%E5%8F%A3%20/media/get
