### PR TITLE
现在创建卡券报错->修改JSON序列化不序列没有使用的BaseCardInfo里的CardType

### DIFF
--- a/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/Card/CardCreate/CardCreateInfo_Card.cs
+++ b/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/Card/CardCreate/CardCreateInfo_Card.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Web.Script.Serialization;
 
 namespace Senparc.Weixin.MP.AdvancedAPIs.Card
 {
@@ -131,6 +132,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs.Card
         /// <summary>
         /// 卡类型（不在Json数据中）
         /// </summary>
+        [ScriptIgnore]
         public CardType CardType { get; set; }
 
         public BaseCardInfo(CardType cardType)


### PR DESCRIPTION
微信创建卡券接口调整，增加JSON检查， 修改JSON序列化不序列没有使用的BaseCardInfo里的CardType，现在创建卡券报错