### PR TITLE
JavaScriptSerializer不能正确解析ExpandoObject对象，修改为是用json.net

### DIFF
--- a/Senparc.Weixin/Senparc.Weixin/Helpers/SerializerHelper.cs
+++ b/Senparc.Weixin/Senparc.Weixin/Helpers/SerializerHelper.cs
@@ -17,6 +17,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web.Script.Serialization;
+using Newtonsoft.Json;
 
 namespace Senparc.Weixin.Helpers
 {
@@ -40,8 +41,7 @@ namespace Senparc.Weixin.Helpers
 
         public string GetJsonString(object data)
         {
-            JavaScriptSerializer js = new JavaScriptSerializer();
-            var jsonString = js.Serialize(data);
+            var jsonString = JsonConvert.SerializeObject(data);
 
             //解码Unicode，也可以通过设置App.Config（Web.Config）设置来做，这里只是暂时弥补一下，用到的地方不多
             MatchEvaluator evaluator = new MatchEvaluator(DecodeUnicode);

--- a/Senparc.Weixin/Senparc.Weixin/Senparc.Weixin.csproj
+++ b/Senparc.Weixin/Senparc.Weixin/Senparc.Weixin.csproj
@@ -34,6 +34,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\Senparc.Weixin.MP\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
@@ -80,7 +84,9 @@
     <Compile Include="Entities\Response\ResponseMessageBase.cs" />
     <Compile Include="Utilities\StreamUtility\StreamUtility.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Senparc.Weixin/Senparc.Weixin/packages.config
+++ b/Senparc.Weixin/Senparc.Weixin/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
JavaScriptSerializer不能正确解析ExpandoObject对象，修改为是用json.net。  
json.net也一样是开源的，类库来自NuGet