### PR TITLE
修复了一些bug

### DIFF
--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/ShakeAround/ShakeAroundApi.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/ShakeAround/ShakeAroundApi.cs
@@ -122,7 +122,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         /// <param name="appId">批次ID，申请设备ID时所返回的批次ID</param>
         /// <param name="timeOut"></param>
         /// <returns></returns>
-        public static GetDeviceStatusResultJson DeviceApplyStatus(string accessTokenOrAppId, int appId, int timeOut = Config.TIME_OUT)
+        public static GetDeviceStatusResultJson DeviceApplyStatus(string accessTokenOrAppId, long appId, int timeOut = Config.TIME_OUT)
         {
             return ApiHandlerWapper.TryCommonApi(accessToken =>
             {
@@ -298,17 +298,17 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         /// 根据分页查询或者指定范围查询设备列表
         /// </summary>
         /// <param name="accessTokenOrAppId"></param>
-        /// <param name="begin"></param>
-        /// <param name="count"></param>
+        /// <param name="lastSeen">前一次查询列表末尾的设备ID，第一次查询lastSeen为0</param>
+        /// <param name="count">待查询的设备数量，不能超过50个</param>
         /// <param name="timeOut"></param>
         /// <returns></returns>
-        public static DeviceSearchResultJson SearchDeviceByRange(string accessTokenOrAppId, int begin, int count, int timeOut = Config.TIME_OUT)
+        public static DeviceSearchResultJson SearchDeviceByRange(string accessTokenOrAppId, int lastSeen, int count, int timeOut = Config.TIME_OUT)
         {
             return ApiHandlerWapper.TryCommonApi(accessToken =>
             {
                 var data = new
                 {
-                    begin = begin,
+                    last_seen = lastSeen,
                     count = count
                 };
 
@@ -321,19 +321,19 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         /// 根据批次ID查询设备列表
         /// </summary>
         /// <param name="accessTokenOrAppId"></param>
-        /// <param name="applyId"></param>
-        /// <param name="begin"></param>
-        /// <param name="count"></param>
+        /// <param name="applyId">批次ID，申请设备ID时所返回的批次ID</param>
+        /// <param name="lastSeen">前一次查询列表末尾的设备ID，第一次查询lastSeen为0</param>
+        /// <param name="count">待查询的设备数量，不能超过50个</param>
         /// <param name="timeOut"></param>
         /// <returns></returns>
-        public static DeviceSearchResultJson SearchDeviceByApplyId(string accessTokenOrAppId, long applyId, int begin, int count, int timeOut = Config.TIME_OUT)
+        public static DeviceSearchResultJson SearchDeviceByApplyId(string accessTokenOrAppId, long applyId, int lastSeen, int count, int timeOut = Config.TIME_OUT)
         {
             return ApiHandlerWapper.TryCommonApi(accessToken =>
             {
                 var data = new
                 {
                     apply_id = applyId,
-                    begin = begin,
+                    last_seen = lastSeen,
                     count = count
                 };
 
@@ -1118,7 +1118,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         /// <param name="appId">批次ID，申请设备ID时所返回的批次ID</param>
         /// <param name="timeOut"></param>
         /// <returns></returns>
-        public static async Task<GetDeviceStatusResultJson> DeviceApplyStatusAsync(string accessTokenOrAppId, int appId, int timeOut = Config.TIME_OUT)
+        public static async Task<GetDeviceStatusResultJson> DeviceApplyStatusAsync(string accessTokenOrAppId, long appId, int timeOut = Config.TIME_OUT)
         {
             return await ApiHandlerWapper.TryCommonApiAsync(accessToken =>
             {
@@ -1461,14 +1461,14 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         /// <param name="count"></param>
         /// <param name="timeOut"></param>
         /// <returns></returns>
-        public static async Task<SearchPagesResultJson> SearchPagesByRangeAsync(string accessTokenOrAppId, int begin, int count,
+        public static async Task<SearchPagesResultJson> SearchPagesByRangeAsync(string accessTokenOrAppId, int lastSeen, int count,
             int timeOut = Config.TIME_OUT)
         {
             return await ApiHandlerWapper.TryCommonApiAsync(accessToken =>
             {
                 var data = new
                 {
-                    begin = begin,
+                    last_seen = lastSeen,
                     count = count
                 };
 

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/WiFi/WiFiApi.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/WiFi/WiFiApi.cs
@@ -277,7 +277,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         /// <param name="imgId"></param>
         /// <param name="timeOut"></param>
         /// <returns></returns>
-        public static WxJsonResult GetQrcode(string accessTokenOrAppId, long shopId, int imgId,
+        public static GetQrcodeResult GetQrcode(string accessTokenOrAppId, long shopId, int imgId,
             int timeOut = Config.TIME_OUT)
         {
             return ApiHandlerWapper.TryCommonApi(accessToken =>
@@ -290,7 +290,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
                     img_id = imgId
                 };
 
-                return CommonJsonSend.Send<WxJsonResult>(accessToken, urlFormat, data, timeOut: timeOut);
+                return CommonJsonSend.Send<GetQrcodeResult>(accessToken, urlFormat, data, timeOut: timeOut);
 
             }, accessTokenOrAppId);
         }
@@ -783,7 +783,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         /// <param name="imgId"></param>
         /// <param name="timeOut"></param>
         /// <returns></returns>
-        public static async Task<WxJsonResult> GetQrcodeAsync(string accessTokenOrAppId, long shopId, int imgId,
+        public static async Task<GetQrcodeResult> GetQrcodeAsync(string accessTokenOrAppId, long shopId, int imgId,
             int timeOut = Config.TIME_OUT)
         {
             return await ApiHandlerWapper.TryCommonApiAsync( accessToken =>
@@ -796,7 +796,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
                     img_id = imgId
                 };
 
-                return Senparc.Weixin.CommonAPIs.CommonJsonSend.SendAsync<WxJsonResult>(accessToken, urlFormat, data, timeOut: timeOut);
+                return Senparc.Weixin.CommonAPIs.CommonJsonSend.SendAsync<GetQrcodeResult>(accessToken, urlFormat, data, timeOut: timeOut);
 
             }, accessTokenOrAppId);
         }

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/WiFi/WiFiJson/WiFiQrcodeResultJson.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/WiFi/WiFiJson/WiFiQrcodeResultJson.cs
@@ -17,7 +17,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs.WiFi
     /// </summary>
     public class GetQrcodeResult : WxJsonResult
     {
-        public GetQrcode_Data date { get; set; }
+        public GetQrcode_Data data { get; set; }
     }
 
     public class GetQrcode_Data


### PR DESCRIPTION
修正了WiFiApi中GetQrcode函数的返回值数据类型。

修正了ShakeAroundApi中申请iBeacon设备的申请批次ID(appId)的数据类型从int改为long。

修正了ShakeAroundApi中查询iBeacon设备传递的参数(begin => last_seen)，跟随微信更新。
https://mp.weixin.qq.com/wiki?action=doc&id=mp1443447624&t=0.6510269819073309

修正了WiFiApi中GetQrcodeResult的bug。