### PR TITLE
修正 NETCore 下 MessageHandler 失效问题

### DIFF
--- a/src/Senparc.Weixin/Senparc.Weixin/Utilities/EntityUtility/EntityUtility.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/Utilities/EntityUtility/EntityUtility.cs
@@ -57,30 +57,23 @@ namespace Senparc.Weixin.EntityUtility
             {
                 return default(T);
             }
-
+            
+            var t = typeof(T);
 #if NET45
-            if (!typeof(T).IsGenericType)
-            {
-                return (T)Convert.ChangeType(convertibleValue, typeof(T));
-            }
+            if (t.IsGenericType)
 #else
-            var genericTypeArguments = typeof(T).GenericTypeArguments;
-            if (genericTypeArguments != null && genericTypeArguments.Length > 0)
-            {
-                return (T)Convert.ChangeType(convertibleValue, typeof(T));
-            }
+            if (t.GetTypeInfo().IsGenericType)
 #endif
-
-
-            else
             {
-                Type genericTypeDefinition = typeof(T).GetGenericTypeDefinition();
-                if (genericTypeDefinition == typeof(Nullable<>))
+                if (t.GetGenericTypeDefinition() != typeof(Nullable<>))
                 {
-                    return (T)Convert.ChangeType(convertibleValue, Nullable.GetUnderlyingType(typeof(T)));
+                    throw new InvalidCastException(string.Format("Invalid cast from type \"{0}\" to type \"{1}\".", convertibleValue.GetType().FullName, typeof(T).FullName));
                 }
+
+                t = Nullable.GetUnderlyingType(t);
             }
-            throw new InvalidCastException(string.Format("Invalid cast from type \"{0}\" to type \"{1}\".", convertibleValue.GetType().FullName, typeof(T).FullName));
+
+            return (T)Convert.ChangeType(convertibleValue, t);
         }
 
 


### PR DESCRIPTION
修正 `EntityUtility.ConvertTo<T>()` 扩展方法非 `NET45` 时逻辑判断错误，此错误会导致 `NETCore` 下运行时 new 任何 `MessageHandler` 子类时会报错 `This operation is only valid on generic types`.