### PR TITLE
解决了QrCode_ActionName.QR_STR_SCENE下临时二维码有效时间expire_seconds不生效的Bug.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -38,7 +38,7 @@
 - [ ] Visual Studio 2012
 - [ ] Visual Studio 2013
 - [ ] Visual Studio 2015
-- [ ] Visual Studio 2017 RC
+- [ ] Visual Studio 2017
 - [ ] 其他：
 
 ##### 缓存环境

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ Senparc 官方教程
 
 购买正版：https://item.jd.com/12220004.html
 
-> 由 Senparc.Weixin SDK 作者亲笔撰写的微信开发图书将于 7 月中旬出版，Senparc 团队全程参与了图书整理工作及配套的 BookHelper 辅助阅读系统开发<br>
+> 由 Senparc.Weixin SDK 作者亲笔撰写的微信开发图书已经出版，众筹签名版及各大电商平台、书店正在备货中，将在7月底前陆续上架并发货，Senparc 团队全程参与了图书整理工作及配套的 BookHelper 辅助阅读系统开发<br>
 书名：《微信开发深度解析：公众号、小程序高效开发秘籍》，可以使用微信扫描下方二维码查看最新进展：<br>
 
 > [![CrowdFunding](http://sdk.weixin.senparc.com/images/crowdfunding-qrcode.png)](https://www.weiweihi.com:8080/CrowdFunding/Home)  

--- a/readme.md
+++ b/readme.md
@@ -16,11 +16,13 @@ Senparc 官方教程
 ----------------
 <img src="http://sdk.weixin.senparc.com/images/book-cover-front-small-3d.jpg" width="400" /> <br >
 
+购买正版：https://item.jd.com/12220004.html
+
 > 由 Senparc.Weixin SDK 作者亲笔撰写的微信开发图书将于 7 月中旬出版，Senparc 团队全程参与了图书整理工作及配套的 BookHelper 辅助阅读系统开发<br>
 书名：《微信开发深度解析：公众号、小程序高效开发秘籍》，可以使用微信扫描下方二维码查看最新进展：<br>
 
 > [![CrowdFunding](http://sdk.weixin.senparc.com/images/crowdfunding-qrcode.png)](https://www.weiweihi.com:8080/CrowdFunding/Home)  
-> 购买正版：https://item.jd.com/12220004.html 
+
 > 图书出版时的代码版本快照见分支 [BookVersion1](https://github.com/JeffreySu/WeiXinMPSDK/tree/BookVersion1)。
 
 

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/QrCode/QrCodeApi.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/QrCode/QrCodeApi.cs
@@ -132,6 +132,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
                     case QrCode_ActionName.QR_STR_SCENE:
                         data = new
                         {
+                            expire_seconds = expireSeconds,
                             action_name = "QR_STR_SCENE",
                             action_info = new
                             {
@@ -268,6 +269,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
                     case QrCode_ActionName.QR_STR_SCENE:
                         data = new
                         {
+                            expire_seconds = expireSeconds,
                             action_name = "QR_STR_SCENE",
                             action_info = new
                             {


### PR DESCRIPTION
问题现象：
当使用QRCode_ActionName.QR_STR_SCENE生成临时二维码，创建成功的二维码的有效时间永远是60秒。
问题原因：
QrCodeApi忘记了在QR_STR_SCENE下设置有效时间。