### PR TITLE
多次 LogBegin 会导致 缩进 对不齐。

### DIFF
--- a/src/Senparc.Weixin/Senparc.Weixin/Trace/WeixinTrace.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/Trace/WeixinTrace.cs
@@ -303,7 +303,7 @@ namespace Senparc.Weixin
             }
 
             LogBegin("[[WeixinException]]");
-            LogBegin(ex.GetType().Name);
+            Log(ex.GetType().Name);
             Log("AccessTokenOrAppId：{0}", ex.AccessTokenOrAppId);
             Log("Message：{0}", ex.Message);
             Log("StackTrace：{0}", ex.StackTrace);
@@ -340,7 +340,7 @@ namespace Senparc.Weixin
             }
 
             LogBegin("[[ErrorJsonResultException]]");
-            LogBegin("ErrorJsonResultException");
+            Log("ErrorJsonResultException");
             Log("AccessTokenOrAppId：{0}", ex.AccessTokenOrAppId ?? "null");
             Log("URL：{0}", ex.Url);
             Log("errcode：{0}", ex.JsonResult.errcode);


### PR DESCRIPTION
建议每次Log，只用一次 LogBegin 。