### PR TITLE
Developer

### DIFF
--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Properties/AssemblyInfo.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Properties/AssemblyInfo.cs
@@ -53,6 +53,6 @@ using System.Runtime.InteropServices;
 // 可以指定所有这些值，也可以使用“生成号”和“修订号”的默认值，
 // 方法是按如下所示使用“*”:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("14.6.1.*")]
+[assembly: AssemblyVersion("14.6.2.*")]
 //[assembly: AssemblyInformationalVersion("13.3.1-alpha")]
 //[assembly: AssemblyFileVersion("0.4.2.0")]


### PR DESCRIPTION
回滚v14.5.5的AccessTokenContainer处理方法，开发者反映“死循环”或不支持Async，是因为AccessTokenContainer内的同步方法调用了异步方法导致。 #762 #749 #701