### PR TITLE
MediaApi.Upload 基于数据流的文件上传

### DIFF
--- a/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Redis/Senparc.Weixin.Cache.Redis.csproj
+++ b/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Redis/Senparc.Weixin.Cache.Redis.csproj
@@ -51,17 +51,16 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Redlock.CSharp, Version=0.0.2.35303, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Senparc.Weixin.MP.Sample\packages\Senparc.Weixin.Cache.Redis.RedLock.0.0.2\lib\net45\Redlock.CSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Senparc.Weixin.Cache.Redis.RedLock, Version=0.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Senparc.Weixin.Cache.Redis.RedLock.0.1.1\lib\net45\Senparc.Weixin.Cache.Redis.RedLock.dll</HintPath>
     </Reference>
-    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Senparc.Weixin.MP.Sample\packages\StackExchange.Redis.1.0.488\lib\net45\StackExchange.Redis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="StackExchange.Redis, Version=1.2.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StackExchange.Redis.1.2.6\lib\net45\StackExchange.Redis.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -86,7 +85,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Redis/packages.config
+++ b/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Redis/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Senparc.Weixin.Cache.Redis.RedLock" version="0.0.2" targetFramework="net45" />
-  <package id="StackExchange.Redis" version="1.0.488" targetFramework="net45" />
+  <package id="Senparc.Weixin.Cache.Redis.RedLock" version="0.1.1" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.2.6" targetFramework="net45" />
 </packages>

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/AdvancedAPIs/Media/MediaTest.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/AdvancedAPIs/Media/MediaTest.cs
@@ -41,7 +41,7 @@ namespace Senparc.Weixin.Work.Test.AdvancedAPIs
         [TestMethod]
         public void UploadVideoTest()
         {
-            string _media = "E:\\test2.mp4";
+            var _media = new HttpUtility.MediaFile("E:\\test2.mp4");
             var accessToken = AccessTokenContainer.GetToken(_corpId, base._corpSecret);
             var result = MediaApi.Upload(accessToken, UploadMediaFileType.video, _media);
             Assert.IsNotNull(result);
@@ -51,7 +51,7 @@ namespace Senparc.Weixin.Work.Test.AdvancedAPIs
         [TestMethod]
         public string UploadImageTest()
         {
-            string _media = "E:\\1.jpg";
+            var _media = new HttpUtility.MediaFile("E:\\1.jpg");
             var accessToken = AccessTokenContainer.GetToken(_corpId, base._corpSecret);
             var result = MediaApi.Upload(accessToken, UploadMediaFileType.image, _media);
             Assert.IsNotNull(result);

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/Senparc.Weixin.Work.Test.csproj
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/Senparc.Weixin.Work.Test.csproj
@@ -48,7 +48,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\Senparc.Weixin.MP.Sample\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.XML" />

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/AdvancedAPIs/Media/MediaApi.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/AdvancedAPIs/Media/MediaApi.cs
@@ -56,12 +56,12 @@ namespace Senparc.Weixin.Work.AdvancedAPIs
         /// <param name="media">form-data中媒体文件标识，有filename、filelength、content-type等信息</param>
         /// <param name="timeOut">代理请求超时时间（毫秒）</param>
         /// <returns></returns>
-        public static UploadTemporaryResultJson Upload(string accessTokenOrAppKey, UploadMediaFileType type, string media, int timeOut = Config.TIME_OUT)
+        public static UploadTemporaryResultJson Upload(string accessTokenOrAppKey, UploadMediaFileType type, IMedia media, int timeOut = Config.TIME_OUT)
         {
             return ApiHandlerWapper.TryCommonApi(accessToken =>
             {
                 var url = string.Format("https://qyapi.weixin.qq.com/cgi-bin/media/upload?access_token={0}&type={1}", accessToken.AsUrlData(), type.ToString());
-                var fileDictionary = new Dictionary<string, string>();
+                var fileDictionary = new Dictionary<string, IMedia>();
                 fileDictionary["media"] = media;
                 return Post.PostFileGetJson<UploadTemporaryResultJson>(url, null, fileDictionary, null, null, null, timeOut);
             }, accessTokenOrAppKey);
@@ -146,12 +146,12 @@ namespace Senparc.Weixin.Work.AdvancedAPIs
         /// <param name="media"></param>
         /// <param name="timeOut"></param>
         /// <returns></returns>
-        public static UploadForeverResultJson AddMaterial(string accessTokenOrAppKey, UploadMediaFileType type, int agentId, string media, int timeOut = Config.TIME_OUT)
+        public static UploadForeverResultJson AddMaterial(string accessTokenOrAppKey, UploadMediaFileType type, int agentId, IMedia media, int timeOut = Config.TIME_OUT)
         {
             return ApiHandlerWapper.TryCommonApi(accessToken =>
             {
                 var url = string.Format("https://qyapi.weixin.qq.com/cgi-bin/material/add_material?agentid={1}&type={2}&access_token={0}", accessToken.AsUrlData(), agentId, type);
-                var fileDictionary = new Dictionary<string, string>();
+                var fileDictionary = new Dictionary<string, IMedia>();
                 fileDictionary["media"] = media;
                 return Post.PostFileGetJson<UploadForeverResultJson>(url, null, fileDictionary, null, null, null, timeOut);
             }, accessTokenOrAppKey);
@@ -341,12 +341,12 @@ namespace Senparc.Weixin.Work.AdvancedAPIs
         /// <param name="media">form-data中媒体文件标识，有filename、filelength、content-type等信息</param>
         /// <param name="timeOut">代理请求超时时间（毫秒）</param>
         /// <returns></returns>
-        public static async Task<UploadTemporaryResultJson> UploadAsync(string accessTokenOrAppKey, UploadMediaFileType type, string media, int timeOut = Config.TIME_OUT)
+        public static async Task<UploadTemporaryResultJson> UploadAsync(string accessTokenOrAppKey, UploadMediaFileType type, IMedia media, int timeOut = Config.TIME_OUT)
         {
             return await ApiHandlerWapper.TryCommonApiAsync(async accessToken =>
             {
                 var url = string.Format("https://qyapi.weixin.qq.com/cgi-bin/media/upload?access_token={0}&type={1}", accessToken.AsUrlData(), type.ToString());
-                var fileDictionary = new Dictionary<string, string>();
+                var fileDictionary = new Dictionary<string, IMedia>();
                 fileDictionary["media"] = media;
                 return await Post.PostFileGetJsonAsync<UploadTemporaryResultJson>(url, null, fileDictionary, null, null, null, timeOut);
             }, accessTokenOrAppKey);
@@ -412,12 +412,12 @@ namespace Senparc.Weixin.Work.AdvancedAPIs
         /// <param name="media"></param>
         /// <param name="timeOut"></param>
         /// <returns></returns>
-        public static async Task<UploadForeverResultJson> AddMaterialAsync(string accessTokenOrAppKey, UploadMediaFileType type, int agentId, string media, int timeOut = Config.TIME_OUT)
+        public static async Task<UploadForeverResultJson> AddMaterialAsync(string accessTokenOrAppKey, UploadMediaFileType type, int agentId, IMedia media, int timeOut = Config.TIME_OUT)
         {
             return await ApiHandlerWapper.TryCommonApiAsync(async accessToken =>
             {
                 var url = string.Format("https://qyapi.weixin.qq.com/cgi-bin/material/add_material?agentid={1}&type={2}&access_token={0}", accessToken.AsUrlData(), agentId, type);
-                var fileDictionary = new Dictionary<string, string>();
+                var fileDictionary = new Dictionary<string, IMedia>();
                 fileDictionary["media"] = media;
                 return await Post.PostFileGetJsonAsync<UploadForeverResultJson>(url, null, fileDictionary, null, null, null, timeOut);
             }, accessTokenOrAppKey);

--- a/src/Senparc.Weixin.Work/nuget.config
+++ b/src/Senparc.Weixin.Work/nuget.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <!--
+            Used to specify the default location to expand packages.
+            See: nuget.exe help install
+            See: nuget.exe help update
+        -->
+    <add key="repositoryPath" value="../packages" />
+  </config>
+  <packageRestore>
+    <add key="enabled" value="True" />
+    <add key="automatic" value="True" />
+  </packageRestore>
+  <packageSources>
+    <!--<add key="nuget" value="https://api.nuget.org/v3/index.json" />-->
+  </packageSources>
+  <activePackageSource>
+    <add key="All" value="(Aggregate source)" />
+  </activePackageSource>
+</configuration>

--- a/src/Senparc.Weixin/Senparc.Weixin/Senparc.Weixin.csproj
+++ b/src/Senparc.Weixin/Senparc.Weixin/Senparc.Weixin.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Utilities\CacheUtility\CacheUtility.cs" />
     <Compile Include="Utilities\CacheUtility\FlushCache.cs" />
     <Compile Include="Utilities\EntityUtility\EntityUtility.cs" />
+    <Compile Include="Utilities\HttpUtility\MediaFile.cs" />
     <Compile Include="Utilities\WeixinUtility\ApiUtility.cs" />
     <Compile Include="Utilities\XmlUtility\XmlUtility.cs" />
     <Compile Include="Utilities\HttpUtility\Get.cs" />

--- a/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/MediaFile.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/MediaFile.cs
@@ -1,0 +1,128 @@
+﻿#region Apache License Version 2.0
+/*----------------------------------------------------------------
+
+Copyright 2017 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
+
+----------------------------------------------------------------*/
+#endregion Apache License Version 2.0
+
+/*----------------------------------------------------------------
+    Copyright (C) 2017 Senparc
+
+    文件名：MediaFile.cs
+    文件功能描述：媒体文件
+
+
+    创建标识：mccj - 20170902
+
+----------------------------------------------------------------*/
+
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Script.Serialization;
+using Senparc.Weixin.Entities;
+using Senparc.Weixin.Exceptions;
+using Senparc.Weixin.Helpers;
+
+namespace Senparc.Weixin.HttpUtility
+{
+    /// <summary>
+    /// 媒体文件接口
+    /// </summary>
+    public interface IMedia
+    {
+        /// <summary>
+        /// 获取文件名
+        /// </summary>
+        /// <returns></returns>
+        string GetFileName();
+        /// <summary>
+        /// 获取文件数据流
+        /// </summary>
+        /// <returns></returns>
+        Stream GetStream();
+    }
+    /// <summary>
+    /// 基于文件的媒体实现
+    /// </summary>
+    public class MediaFile : IMedia
+    {
+        private readonly string _fileName;
+        public MediaFile(string fileName)
+        {
+            _fileName = fileName;
+        }
+        public string GetFileName()
+        {
+            return _fileName;
+        }
+
+        public Stream GetStream()
+        {
+            return FileHelper.GetFileStream(_fileName);
+        }
+    }
+    /// <summary>
+    /// 基于字节的媒体实现
+    /// </summary>
+    public class MediaBytes : IMedia
+    {
+        private readonly Func<byte[]> _getBytes;
+        public MediaBytes(byte[] bytes) : this(() => bytes) { }
+        public MediaBytes(Func<byte[]> getBytes)
+        {
+            _getBytes = getBytes;
+        }
+        public string GetFileName()
+        {
+            return System.Guid.NewGuid().ToString("N");
+        }
+        public Stream GetStream()
+        {
+            var stream = new MemoryStream();
+            var bytes = _getBytes();
+            stream.Write(bytes, 0, bytes.Length);
+            return stream;
+        }
+    }
+    /// <summary>
+    /// 基于流的媒体实现
+    /// </summary>
+    public class MediaStream : IMedia
+    {
+        private readonly Func<Stream> _getStream;
+        public MediaStream(Stream stream) : this(() => stream) { }
+        public MediaStream(Func<Stream> getStream)
+        {
+            _getStream = getStream;
+        }
+        public string GetFileName()
+        {
+            return System.Guid.NewGuid().ToString("N");
+        }
+        public Stream GetStream()
+        {
+            var stream = _getStream();
+            stream.Position = 0;
+            return stream;
+        }
+    }
+
+}

--- a/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/Post.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/Post.cs
@@ -114,7 +114,7 @@ namespace Senparc.Weixin.HttpUtility
         /// <param name="fileDictionary"></param>
         /// <param name="postDataDictionary"></param>
         /// <returns></returns>
-        public static T PostFileGetJson<T>(string url, CookieContainer cookieContainer = null, Dictionary<string, string> fileDictionary = null, Dictionary<string, string> postDataDictionary = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT)
+        public static T PostFileGetJson<T>(string url, CookieContainer cookieContainer = null, Dictionary<string, IMedia> fileDictionary = null, Dictionary<string, string> postDataDictionary = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT)
         {
             using (MemoryStream ms = new MemoryStream())
             {
@@ -200,7 +200,7 @@ namespace Senparc.Weixin.HttpUtility
         /// <param name="fileDictionary"></param>
         /// <param name="postDataDictionary"></param>
         /// <returns></returns>
-        public static async Task<T> PostFileGetJsonAsync<T>(string url, CookieContainer cookieContainer = null, Dictionary<string, string> fileDictionary = null, Dictionary<string, string> postDataDictionary = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT)
+        public static async Task<T> PostFileGetJsonAsync<T>(string url, CookieContainer cookieContainer = null, Dictionary<string, IMedia> fileDictionary = null, Dictionary<string, string> postDataDictionary = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT)
         {
             using (MemoryStream ms = new MemoryStream())
             {

--- a/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/RequestUtility.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/RequestUtility.cs
@@ -182,7 +182,7 @@ namespace Senparc.Weixin.HttpUtility
         /// <param name="checkValidationResult">验证服务器证书回调自动验证</param>
         /// <param name="refererUrl"></param>
         /// <returns></returns>
-        public static string HttpPost(string url, CookieContainer cookieContainer = null, Stream postStream = null, Dictionary<string, string> fileDictionary = null, string refererUrl = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT, bool checkValidationResult = false)
+        public static string HttpPost(string url, CookieContainer cookieContainer = null, Stream postStream = null, Dictionary<string, IMedia> fileDictionary = null, string refererUrl = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT, bool checkValidationResult = false)
         {
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
             request.Method = "POST";
@@ -215,15 +215,15 @@ namespace Senparc.Weixin.HttpUtility
                 {
                     try
                     {
-                        var fileName = file.Value;
+                        var mediaFile = file.Value;
                         //准备文件流
-                        using (var fileStream = FileHelper.GetFileStream(fileName))
+                        using (var fileStream = mediaFile.GetStream())
                         {
                             string formdata = null;
                             if (fileStream != null)
                             {
                                 //存在文件
-                                formdata = string.Format(fileFormdataTemplate, file.Key, /*fileName*/ Path.GetFileName(fileName));
+                                formdata = string.Format(fileFormdataTemplate, file.Key, /*fileName*/ Path.GetFileName(mediaFile.GetFileName()));
                             }
                             else
                             {
@@ -417,7 +417,7 @@ namespace Senparc.Weixin.HttpUtility
         /// <param name="timeOut"></param>
         /// <param name="checkValidationResult">验证服务器证书回调自动验证</param>
         /// <returns></returns>
-        public static async Task<string> HttpPostAsync(string url, CookieContainer cookieContainer = null, Stream postStream = null, Dictionary<string, string> fileDictionary = null, string refererUrl = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT, bool checkValidationResult = false)
+        public static async Task<string> HttpPostAsync(string url, CookieContainer cookieContainer = null, Stream postStream = null, Dictionary<string, IMedia> fileDictionary = null, string refererUrl = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT, bool checkValidationResult = false)
         {
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
             request.Method = "POST";
@@ -450,15 +450,15 @@ namespace Senparc.Weixin.HttpUtility
                 {
                     try
                     {
-                        var fileName = file.Value;
+                        var mediaFile = file.Value;
                         //准备文件流
-                        using (var fileStream = FileHelper.GetFileStream(fileName))
+                        using (var fileStream = mediaFile.GetStream())
                         {
                             string formdata = null;
                             if (fileStream != null)
                             {
                                 //存在文件
-                                formdata = string.Format(fileFormdataTemplate, file.Key, /*fileName*/ Path.GetFileName(fileName));
+                                formdata = string.Format(fileFormdataTemplate, file.Key, /*fileName*/ Path.GetFileName(mediaFile.GetFileName()));
                             }
                             else
                             {


### PR DESCRIPTION
MediaApi.Upload 上传是基于文件的，使用非常不方便，现修改成可以基于字节及数据流的方式上传
1.增加 IMedia 接口，实现类 MediaFile、MediaBytes、MediaStream，分别用来基于文件、字节、数据流 的上传方式
2.修改Senparc.Weixin.HttpUtility.RequestUtility 类 HttpPost 和 HttpPostAsync 方法中的参数 Dictionary<string, string> fileDictionary 修改成 Dictionary<string, IMedia> fileDictionary
3.该方法相关联的其他方法做对应的修改