### PR TITLE
MediaApi.Upload 基于数据流的文件上传

### DIFF
--- a/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Redis.RedLock/redlock-cs/redlock-cs.sln
+++ b/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Redis.RedLock/redlock-cs/redlock-cs.sln
@@ -1,34 +1,25 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26206.0
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "redlock-cs", "src\redlock-cs.csproj", "{F558DFFC-8650-45D7-96C4-84470500C517}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Senparc.Weixin.Cache.Redis.RedLock", "src\Senparc.Weixin.Cache.Redis.RedLock.csproj", "{EE3E4714-B671-4C07-A40F-C322B1716821}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F558DFFC-8650-45D7-96C4-84470500C517}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F558DFFC-8650-45D7-96C4-84470500C517}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F558DFFC-8650-45D7-96C4-84470500C517}.Debug|x64.ActiveCfg = Debug|x64
-		{F558DFFC-8650-45D7-96C4-84470500C517}.Debug|x64.Build.0 = Debug|x64
-		{F558DFFC-8650-45D7-96C4-84470500C517}.Debug|x86.ActiveCfg = Debug|x86
-		{F558DFFC-8650-45D7-96C4-84470500C517}.Debug|x86.Build.0 = Debug|x86
-		{F558DFFC-8650-45D7-96C4-84470500C517}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F558DFFC-8650-45D7-96C4-84470500C517}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F558DFFC-8650-45D7-96C4-84470500C517}.Release|x64.ActiveCfg = Release|x64
-		{F558DFFC-8650-45D7-96C4-84470500C517}.Release|x64.Build.0 = Release|x64
-		{F558DFFC-8650-45D7-96C4-84470500C517}.Release|x86.ActiveCfg = Release|x86
-		{F558DFFC-8650-45D7-96C4-84470500C517}.Release|x86.Build.0 = Release|x86
+		{EE3E4714-B671-4C07-A40F-C322B1716821}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE3E4714-B671-4C07-A40F-C322B1716821}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE3E4714-B671-4C07-A40F-C322B1716821}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE3E4714-B671-4C07-A40F-C322B1716821}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {991F8F0F-2097-4C56-B217-C96394703A88}
 	EndGlobalSection
 EndGlobal

--- a/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Redis/Senparc.Weixin.Cache.Redis.csproj
+++ b/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Redis/Senparc.Weixin.Cache.Redis.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
-    <Version>1.3.0</Version>
+    <Version>4.14.3</Version>
     <AssemblyName>Senparc.Weixin.Cache.Redis</AssemblyName>
     <RootNamespace>Senparc.Weixin.Cache.Redis</RootNamespace>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Redis/Senparc.Weixin.Cache.Redis.net45.csproj
+++ b/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Redis/Senparc.Weixin.Cache.Redis.net45.csproj
@@ -52,7 +52,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Redlock.CSharp, Version=0.0.2.35303, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Senparc.Weixin.MP.Sample\packages\Senparc.Weixin.Cache.Redis.RedLock.0.0.2\lib\net45\Redlock.CSharp.dll</HintPath>
+      <HintPath>..\..\packages\Senparc.Weixin.Cache.Redis.RedLock.0.0.2\lib\net45\Redlock.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/AdvancedAPIs/Media/MediaTest.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/AdvancedAPIs/Media/MediaTest.cs
@@ -41,7 +41,7 @@ namespace Senparc.Weixin.Work.Test.AdvancedAPIs
         [TestMethod]
         public void UploadVideoTest()
         {
-            string _media = "E:\\test2.mp4";
+            var _media = new HttpUtility.MediaFile("E:\\test2.mp4");
             var accessToken = AccessTokenContainer.GetToken(_corpId, base._corpSecret);
             var result = MediaApi.Upload(accessToken, UploadMediaFileType.video, _media);
             Assert.IsNotNull(result);
@@ -51,7 +51,7 @@ namespace Senparc.Weixin.Work.Test.AdvancedAPIs
         [TestMethod]
         public string UploadImageTest()
         {
-            string _media = "E:\\1.jpg";
+            var _media = new HttpUtility.MediaFile("E:\\1.jpg");
             var accessToken = AccessTokenContainer.GetToken(_corpId, base._corpSecret);
             var result = MediaApi.Upload(accessToken, UploadMediaFileType.image, _media);
             Assert.IsNotNull(result);

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/Senparc.Weixin.Work.Test.csproj
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/Senparc.Weixin.Work.Test.csproj
@@ -48,7 +48,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\Senparc.Weixin.MP.Sample\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.XML" />

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work.net45.sln
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work.net45.sln
@@ -1,15 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Senparc.Weixin.Work", "Senparc.Weixin.Work\Senparc.Weixin.Work.csproj", "{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Senparc.Weixin.Work", "Senparc.Weixin.Work\Senparc.Weixin.Work.csproj", "{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Senparc.Weixin.Work.Test", "Senparc.Weixin.Work.Test\Senparc.Weixin.Work.Test.csproj", "{D18608FC-F6A9-4D40-A5D4-BDDA3B1D300E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Senparc.Weixin", "..\Senparc.Weixin\Senparc.Weixin\Senparc.Weixin.csproj", "{814092CD-9CD0-4FB7-91E8-D147F476F1FB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Senparc.Weixin", "..\Senparc.Weixin\Senparc.Weixin\Senparc.Weixin.csproj", "{814092CD-9CD0-4FB7-91E8-D147F476F1FB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Senparc.Weixin.Cache.Redis", "..\Senparc.Weixin.Cache\Senparc.Weixin.Cache.Redis\Senparc.Weixin.Cache.Redis.csproj", "{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Senparc.Weixin.Cache.Redis", "..\Senparc.Weixin.Cache\Senparc.Weixin.Cache.Redis\Senparc.Weixin.Cache.Redis.csproj", "{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Senparc.Weixin.Cache.Redis.RedLock", "..\Senparc.Weixin.Cache\Senparc.Weixin.Cache.Redis.RedLock\redlock-cs\src\Senparc.Weixin.Cache.Redis.RedLock.csproj", "{E0F7DBC3-590E-46F7-A711-4D22C63E7849}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,16 +25,16 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Debug|x86.ActiveCfg = Debug|x86
-		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Debug|x86.Build.0 = Debug|x86
+		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Debug|x86.Build.0 = Debug|Any CPU
 		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Release|x86.ActiveCfg = Release|x86
-		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Release|x86.Build.0 = Release|x86
-		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Test|Any CPU.ActiveCfg = Test|Any CPU
-		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Test|Any CPU.Build.0 = Test|Any CPU
-		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Test|x86.ActiveCfg = Test|x86
-		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Test|x86.Build.0 = Test|x86
+		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Release|x86.ActiveCfg = Release|Any CPU
+		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Release|x86.Build.0 = Release|Any CPU
+		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Test|Any CPU.ActiveCfg = Release|Any CPU
+		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Test|Any CPU.Build.0 = Release|Any CPU
+		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Test|x86.ActiveCfg = Release|Any CPU
+		{CC0EBEC4-7120-4627-A596-C1F2958F3D5E}.Test|x86.Build.0 = Release|Any CPU
 		{D18608FC-F6A9-4D40-A5D4-BDDA3B1D300E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D18608FC-F6A9-4D40-A5D4-BDDA3B1D300E}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{D18608FC-F6A9-4D40-A5D4-BDDA3B1D300E}.Debug|x86.Build.0 = Debug|Any CPU
@@ -46,30 +48,45 @@ Global
 		{D18608FC-F6A9-4D40-A5D4-BDDA3B1D300E}.Test|x86.Build.0 = Test|Any CPU
 		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Debug|x86.ActiveCfg = Debug|x86
-		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Debug|x86.Build.0 = Debug|x86
+		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Debug|x86.Build.0 = Debug|Any CPU
 		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Release|x86.ActiveCfg = Release|x86
-		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Release|x86.Build.0 = Release|x86
-		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Test|Any CPU.ActiveCfg = Test|Any CPU
-		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Test|Any CPU.Build.0 = Test|Any CPU
-		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Test|x86.ActiveCfg = Test|x86
-		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Test|x86.Build.0 = Test|x86
+		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Release|x86.ActiveCfg = Release|Any CPU
+		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Release|x86.Build.0 = Release|Any CPU
+		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Test|Any CPU.ActiveCfg = Release|Any CPU
+		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Test|Any CPU.Build.0 = Release|Any CPU
+		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Test|x86.ActiveCfg = Release|Any CPU
+		{814092CD-9CD0-4FB7-91E8-D147F476F1FB}.Test|x86.Build.0 = Release|Any CPU
 		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Debug|x86.ActiveCfg = Debug|x86
-		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Debug|x86.Build.0 = Debug|x86
+		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Debug|x86.Build.0 = Debug|Any CPU
 		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Release|x86.ActiveCfg = Release|x86
-		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Release|x86.Build.0 = Release|x86
+		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Release|x86.ActiveCfg = Release|Any CPU
+		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Release|x86.Build.0 = Release|Any CPU
 		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Test|Any CPU.ActiveCfg = Release|Any CPU
 		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Test|Any CPU.Build.0 = Release|Any CPU
-		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Test|x86.ActiveCfg = Release|x86
-		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Test|x86.Build.0 = Release|x86
+		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Test|x86.ActiveCfg = Release|Any CPU
+		{51AC27B4-11AE-4F59-B82A-0BB3AFA5F62B}.Test|x86.Build.0 = Release|Any CPU
+		{E0F7DBC3-590E-46F7-A711-4D22C63E7849}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E0F7DBC3-590E-46F7-A711-4D22C63E7849}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E0F7DBC3-590E-46F7-A711-4D22C63E7849}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E0F7DBC3-590E-46F7-A711-4D22C63E7849}.Debug|x86.Build.0 = Debug|Any CPU
+		{E0F7DBC3-590E-46F7-A711-4D22C63E7849}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E0F7DBC3-590E-46F7-A711-4D22C63E7849}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E0F7DBC3-590E-46F7-A711-4D22C63E7849}.Release|x86.ActiveCfg = Release|Any CPU
+		{E0F7DBC3-590E-46F7-A711-4D22C63E7849}.Release|x86.Build.0 = Release|Any CPU
+		{E0F7DBC3-590E-46F7-A711-4D22C63E7849}.Test|Any CPU.ActiveCfg = Release|Any CPU
+		{E0F7DBC3-590E-46F7-A711-4D22C63E7849}.Test|Any CPU.Build.0 = Release|Any CPU
+		{E0F7DBC3-590E-46F7-A711-4D22C63E7849}.Test|x86.ActiveCfg = Release|Any CPU
+		{E0F7DBC3-590E-46F7-A711-4D22C63E7849}.Test|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B29598A9-1A0D-4F70-9DB8-887ACB2148E3}
 	EndGlobalSection
 EndGlobal

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/AdvancedAPIs/Media/MediaApi.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/AdvancedAPIs/Media/MediaApi.cs
@@ -24,6 +24,8 @@
     修改标识：Senparc - 20170712
     修改描述：v14.5.1 AccessToken HandlerWaper改造
 
+    修改标识：mccj - 20170907
+    修改描述：v4.14.3 修改 MediaApi 的 Upload()、AddMaterial()、UploadAsync()、AddMaterialAsync()等方法 添加文件流的支持,通过 IMedia 接口扩展不同数据流的载体
 ----------------------------------------------------------------*/
 
 /*
@@ -56,12 +58,12 @@ namespace Senparc.Weixin.Work.AdvancedAPIs
         /// <param name="media">form-data中媒体文件标识，有filename、filelength、content-type等信息</param>
         /// <param name="timeOut">代理请求超时时间（毫秒）</param>
         /// <returns></returns>
-        public static UploadTemporaryResultJson Upload(string accessTokenOrAppKey, UploadMediaFileType type, string media, int timeOut = Config.TIME_OUT)
+        public static UploadTemporaryResultJson Upload(string accessTokenOrAppKey, UploadMediaFileType type, IMedia media, int timeOut = Config.TIME_OUT)
         {
             return ApiHandlerWapper.TryCommonApi(accessToken =>
             {
                 var url = string.Format("https://qyapi.weixin.qq.com/cgi-bin/media/upload?access_token={0}&type={1}", accessToken.AsUrlData(), type.ToString());
-                var fileDictionary = new Dictionary<string, string>();
+                var fileDictionary = new Dictionary<string, IMedia>();
                 fileDictionary["media"] = media;
                 return Post.PostFileGetJson<UploadTemporaryResultJson>(url, null, fileDictionary, null, null, null, timeOut);
             }, accessTokenOrAppKey);
@@ -146,12 +148,12 @@ namespace Senparc.Weixin.Work.AdvancedAPIs
         /// <param name="media"></param>
         /// <param name="timeOut"></param>
         /// <returns></returns>
-        public static UploadForeverResultJson AddMaterial(string accessTokenOrAppKey, UploadMediaFileType type, int agentId, string media, int timeOut = Config.TIME_OUT)
+        public static UploadForeverResultJson AddMaterial(string accessTokenOrAppKey, UploadMediaFileType type, int agentId, IMedia media, int timeOut = Config.TIME_OUT)
         {
             return ApiHandlerWapper.TryCommonApi(accessToken =>
             {
                 var url = string.Format("https://qyapi.weixin.qq.com/cgi-bin/material/add_material?agentid={1}&type={2}&access_token={0}", accessToken.AsUrlData(), agentId, type);
-                var fileDictionary = new Dictionary<string, string>();
+                var fileDictionary = new Dictionary<string, IMedia>();
                 fileDictionary["media"] = media;
                 return Post.PostFileGetJson<UploadForeverResultJson>(url, null, fileDictionary, null, null, null, timeOut);
             }, accessTokenOrAppKey);
@@ -341,12 +343,12 @@ namespace Senparc.Weixin.Work.AdvancedAPIs
         /// <param name="media">form-data中媒体文件标识，有filename、filelength、content-type等信息</param>
         /// <param name="timeOut">代理请求超时时间（毫秒）</param>
         /// <returns></returns>
-        public static async Task<UploadTemporaryResultJson> UploadAsync(string accessTokenOrAppKey, UploadMediaFileType type, string media, int timeOut = Config.TIME_OUT)
+        public static async Task<UploadTemporaryResultJson> UploadAsync(string accessTokenOrAppKey, UploadMediaFileType type, IMedia media, int timeOut = Config.TIME_OUT)
         {
             return await ApiHandlerWapper.TryCommonApiAsync(async accessToken =>
             {
                 var url = string.Format("https://qyapi.weixin.qq.com/cgi-bin/media/upload?access_token={0}&type={1}", accessToken.AsUrlData(), type.ToString());
-                var fileDictionary = new Dictionary<string, string>();
+                var fileDictionary = new Dictionary<string, IMedia>();
                 fileDictionary["media"] = media;
                 return await Post.PostFileGetJsonAsync<UploadTemporaryResultJson>(url, null, fileDictionary, null, null, null, timeOut);
             }, accessTokenOrAppKey);
@@ -412,12 +414,12 @@ namespace Senparc.Weixin.Work.AdvancedAPIs
         /// <param name="media"></param>
         /// <param name="timeOut"></param>
         /// <returns></returns>
-        public static async Task<UploadForeverResultJson> AddMaterialAsync(string accessTokenOrAppKey, UploadMediaFileType type, int agentId, string media, int timeOut = Config.TIME_OUT)
+        public static async Task<UploadForeverResultJson> AddMaterialAsync(string accessTokenOrAppKey, UploadMediaFileType type, int agentId, IMedia media, int timeOut = Config.TIME_OUT)
         {
             return await ApiHandlerWapper.TryCommonApiAsync(async accessToken =>
             {
                 var url = string.Format("https://qyapi.weixin.qq.com/cgi-bin/material/add_material?agentid={1}&type={2}&access_token={0}", accessToken.AsUrlData(), agentId, type);
-                var fileDictionary = new Dictionary<string, string>();
+                var fileDictionary = new Dictionary<string, IMedia>();
                 fileDictionary["media"] = media;
                 return await Post.PostFileGetJsonAsync<UploadForeverResultJson>(url, null, fileDictionary, null, null, null, timeOut);
             }, accessTokenOrAppKey);

--- a/src/Senparc.Weixin.Work/nuget.config
+++ b/src/Senparc.Weixin.Work/nuget.config
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <!--
+            Used to specify the default location to expand packages.
+            See: nuget.exe help install
+            See: nuget.exe help update
+        -->
+    <add key="repositoryPath" value="../packages" />
+  </config>
+  <packageRestore>
+    <add key="enabled" value="True" />
+    <add key="automatic" value="True" />
+  </packageRestore>
+  <packageSources>
+    <!--<add key="nuget" value="https://api.nuget.org/v3/index.json" />-->
+  </packageSources>
+  <activePackageSource>
+    <add key="All" value="(Aggregate source)" />
+  </activePackageSource>
+</configuration>

--- a/src/Senparc.Weixin/Senparc.Weixin/Senparc.Weixin.csproj
+++ b/src/Senparc.Weixin/Senparc.Weixin/Senparc.Weixin.csproj
@@ -225,7 +225,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
   
   

--- a/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/MediaFile.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/MediaFile.cs
@@ -1,0 +1,120 @@
+﻿#region Apache License Version 2.0
+/*----------------------------------------------------------------
+
+Copyright 2017 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
+
+----------------------------------------------------------------*/
+#endregion Apache License Version 2.0
+
+/*----------------------------------------------------------------
+    Copyright (C) 2017 Senparc
+
+    文件名：MediaFile.cs
+    文件功能描述：媒体文件载体(用于推送文件)
+
+
+    创建标识：mccj - 20170902
+
+----------------------------------------------------------------*/
+
+
+using Senparc.Weixin.Helpers;
+using System;
+using System.IO;
+
+namespace Senparc.Weixin.HttpUtility
+{
+    /// <summary>
+    /// 媒体文件接口
+    /// </summary>
+    public interface IMedia
+    {
+        /// <summary>
+        /// 获取文件名
+        /// </summary>
+        /// <returns></returns>
+        string GetFileName();
+        /// <summary>
+        /// 获取文件数据流
+        /// </summary>
+        /// <returns></returns>
+        Stream GetStream();
+    }
+    /// <summary>
+    /// 基于文件的媒体实现
+    /// </summary>
+    public class MediaFile : IMedia
+    {
+        private readonly string _fileName;
+        public MediaFile(string fileName)
+        {
+            _fileName = fileName;
+        }
+        public string GetFileName()
+        {
+            return _fileName;
+        }
+
+        public Stream GetStream()
+        {
+            return FileHelper.GetFileStream(_fileName);
+        }
+    }
+    /// <summary>
+    /// 基于字节的媒体实现
+    /// </summary>
+    public class MediaBytes : IMedia
+    {
+        private readonly Func<byte[]> _getBytes;
+        public MediaBytes(byte[] bytes) : this(() => bytes) { }
+        public MediaBytes(Func<byte[]> getBytes)
+        {
+            _getBytes = getBytes;
+        }
+        public string GetFileName()
+        {
+            return System.Guid.NewGuid().ToString("N");
+        }
+        public Stream GetStream()
+        {
+            var stream = new MemoryStream();
+            var bytes = _getBytes();
+            stream.Write(bytes, 0, bytes.Length);
+            return stream;
+        }
+    }
+    /// <summary>
+    /// 基于流的媒体实现
+    /// </summary>
+    public class MediaStream : IMedia
+    {
+        private readonly Func<Stream> _getStream;
+        public MediaStream(Stream stream) : this(() => stream) { }
+        public MediaStream(Func<Stream> getStream)
+        {
+            _getStream = getStream;
+        }
+        public string GetFileName()
+        {
+            return System.Guid.NewGuid().ToString("N");
+        }
+        public Stream GetStream()
+        {
+            var stream = _getStream();
+            stream.Position = 0;
+            return stream;
+        }
+    }
+}

--- a/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/Post.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/Post.cs
@@ -44,6 +44,10 @@ Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
 
     修改标识：Senparc - 20170409
     修改描述：v4.11.9 修改Download方法
+
+    修改标识：mccj - 20170907
+    修改描述：v4.14.3 修改 Post.PostFileGetJson()方法 和 Post.PostFileGetJsonAsync()方法 添加文件流的支持,通过 IMedia 接口扩展不同数据流的载体
+
 ----------------------------------------------------------------*/
 
 
@@ -126,7 +130,7 @@ namespace Senparc.Weixin.HttpUtility
         /// <param name="fileDictionary"></param>
         /// <param name="postDataDictionary"></param>
         /// <returns></returns>
-        public static T PostFileGetJson<T>(string url, CookieContainer cookieContainer = null, Dictionary<string, string> fileDictionary = null, Dictionary<string, string> postDataDictionary = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT)
+        public static T PostFileGetJson<T>(string url, CookieContainer cookieContainer = null, Dictionary<string, IMedia> fileDictionary = null, Dictionary<string, string> postDataDictionary = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT)
         {
             using (MemoryStream ms = new MemoryStream())
             {
@@ -224,7 +228,7 @@ namespace Senparc.Weixin.HttpUtility
         /// <param name="fileDictionary"></param>
         /// <param name="postDataDictionary"></param>
         /// <returns></returns>
-        public static async Task<T> PostFileGetJsonAsync<T>(string url, CookieContainer cookieContainer = null, Dictionary<string, string> fileDictionary = null, Dictionary<string, string> postDataDictionary = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT)
+        public static async Task<T> PostFileGetJsonAsync<T>(string url, CookieContainer cookieContainer = null, Dictionary<string, IMedia> fileDictionary = null, Dictionary<string, string> postDataDictionary = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT)
         {
             using (MemoryStream ms = new MemoryStream())
             {

--- a/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/RequestUtility.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/RequestUtility.cs
@@ -41,6 +41,9 @@ Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
     修改标识：Senparc - 20170730
     修改描述：v4.13.3 为RequestUtility.HttpGet()方法添加Accept、UserAgent、KeepAlive设置
 
+    修改标识：mccj - 20170907
+    修改描述：v4.14.3 为RequestUtility.HttpPost()方法 和 RequestUtility.HttpPostAsync()方法 添加文件流的支持,通过 IMedia 接口扩展不同数据流的载体
+
 ----------------------------------------------------------------*/
 
 using System;
@@ -238,7 +241,7 @@ namespace Senparc.Weixin.HttpUtility
         /// <param name="checkValidationResult">验证服务器证书回调自动验证</param>
         /// <param name="refererUrl"></param>
         /// <returns></returns>
-        public static string HttpPost(string url, CookieContainer cookieContainer = null, Stream postStream = null, Dictionary<string, string> fileDictionary = null, string refererUrl = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT, bool checkValidationResult = false)
+        public static string HttpPost(string url, CookieContainer cookieContainer = null, Stream postStream = null, Dictionary<string, IMedia> fileDictionary = null, string refererUrl = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT, bool checkValidationResult = false)
         {
 
 #if NET45
@@ -309,21 +312,21 @@ namespace Senparc.Weixin.HttpUtility
                 {
                     try
                     {
-                        var fileName = file.Value;
+                        var mediaFile = file.Value;
                         //准备文件流
-                        using (var fileStream = FileHelper.GetFileStream(fileName))
+                        using (var fileStream = mediaFile.GetStream())
                         {
 #if NET45
                             string formdata = null;
                             if (fileStream != null)
                             {
                                 //存在文件
-                                formdata = string.Format(fileFormdataTemplate, file.Key, /*fileName*/ Path.GetFileName(fileName));
+                                formdata = string.Format(fileFormdataTemplate, file.Key, /*fileName*/ Path.GetFileName(mediaFile.GetFileName()));
                             }
                             else
                             {
                                 //不存在文件或只是注释
-                                formdata = string.Format(dataFormdataTemplate, file.Key, file.Value);
+                                formdata = string.Format(dataFormdataTemplate, file.Key, mediaFile.GetFileName());
                             }
 
                             //统一处理
@@ -346,12 +349,12 @@ namespace Senparc.Weixin.HttpUtility
                                 //存在文件
                                 //hc.Add(new StreamContent(fileStream), file.Key, Path.GetFileName(fileName)); //报流已关闭的异常
                                 fileStream.Dispose();
-                                (hc as MultipartFormDataContent).Add(CreateFileContent(File.Open(fileName, FileMode.Open), Path.GetFileName(fileName)), file.Key, Path.GetFileName(fileName));
+                                (hc as MultipartFormDataContent).Add(CreateFileContent(mediaFile.GetStream(), Path.GetFileName(mediaFile.GetFileName())), file.Key, Path.GetFileName(mediaFile.GetFileName()));
                             }
                             else
                             {
                                 //不存在文件或只是注释
-                                (hc as MultipartFormDataContent).Add(new StringContent(string.Empty), file.Key, file.Value);
+                                (hc as MultipartFormDataContent).Add(new StringContent(string.Empty), file.Key, mediaFile.GetFileName());
                             }
 #endif
                         }
@@ -600,7 +603,7 @@ namespace Senparc.Weixin.HttpUtility
         /// <param name="timeOut"></param>
         /// <param name="checkValidationResult">验证服务器证书回调自动验证</param>
         /// <returns></returns>
-        public static async Task<string> HttpPostAsync(string url, CookieContainer cookieContainer = null, Stream postStream = null, Dictionary<string, string> fileDictionary = null, string refererUrl = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT, bool checkValidationResult = false)
+        public static async Task<string> HttpPostAsync(string url, CookieContainer cookieContainer = null, Stream postStream = null, Dictionary<string, IMedia> fileDictionary = null, string refererUrl = null, Encoding encoding = null, X509Certificate2 cer = null, int timeOut = Config.TIME_OUT, bool checkValidationResult = false)
         {
 
 #if NET45
@@ -666,21 +669,21 @@ namespace Senparc.Weixin.HttpUtility
                 {
                     try
                     {
-                        var fileName = file.Value;
+                        var mediaFile = file.Value;
                         //准备文件流
-                        using (var fileStream = FileHelper.GetFileStream(fileName))
+                        using (var fileStream = mediaFile.GetStream())
                         {
 #if NET45
                             string formdata = null;
                             if (fileStream != null)
                             {
                                 //存在文件
-                                formdata = string.Format(fileFormdataTemplate, file.Key, /*fileName*/ Path.GetFileName(fileName));
+                                formdata = string.Format(fileFormdataTemplate, file.Key, /*fileName*/ Path.GetFileName(mediaFile.GetFileName()));
                             }
                             else
                             {
                                 //不存在文件或只是注释
-                                formdata = string.Format(dataFormdataTemplate, file.Key, file.Value);
+                                formdata = string.Format(dataFormdataTemplate, file.Key, mediaFile.GetFileName());
                             }
 
                             //统一处理
@@ -703,12 +706,12 @@ namespace Senparc.Weixin.HttpUtility
                                 //存在文件
                                 //hc.Add(new StreamContent(fileStream), file.Key, Path.GetFileName(fileName)); //报流已关闭的异常
                                 fileStream.Dispose();
-                                (hc as MultipartFormDataContent).Add(CreateFileContent(File.Open(fileName, FileMode.Open), Path.GetFileName(fileName)), file.Key, Path.GetFileName(fileName));
+                                (hc as MultipartFormDataContent).Add(CreateFileContent(mediaFile.GetStream(), Path.GetFileName(mediaFile.GetFileName())), file.Key, Path.GetFileName(mediaFile.GetFileName()));
                             }
                             else
                             {
                                 //不存在文件或只是注释
-                                (hc as MultipartFormDataContent).Add(new StringContent(string.Empty), file.Key, file.Value);
+                                (hc as MultipartFormDataContent).Add(new StringContent(string.Empty), file.Key, mediaFile.GetFileName());
                             }
 #endif
                         }


### PR DESCRIPTION
MediaApi.Upload 上传是基于文件的，使用非常不方便，现修改成可以基于字节及数据流的方式上传
1.增加 IMedia 接口，实现类 MediaFile、MediaBytes、MediaStream，分别用来基于文件、字节、数据流 的上传方式
2.修改Senparc.Weixin.HttpUtility.RequestUtility 类 HttpPost 和 HttpPostAsync 方法中的参数 Dictionary<string, string> fileDictionary 修改成 Dictionary<string, IMedia> fileDictionary
3.该方法相关联的其他方法做对应的修改