### PR TITLE
Fix #969，修正GetMenu()返回菜单内容为NULL 

### DIFF
--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Entities/JsonResult/GetMenuResultFull.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Entities/JsonResult/GetMenuResultFull.cs
@@ -21,11 +21,6 @@ namespace Senparc.Weixin.Work
     /// </summary>
     public class GetMenuResultFull : WorkJsonResult
     {
-        public MenuFull_ButtonGroup menu { get; set; }
-    }
-
-    public class MenuFull_ButtonGroup
-    {
         public List<MenuFull_RootButton> button { get; set; }
     }
 


### PR DESCRIPTION
解决GetMenu由于JSON反序列化失败导致返回菜单内容为NULL的问题 #969 