### PR TITLE
Enable WebProxy in core version

### DIFF
--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/CommonAPIs/CommonApi.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/CommonAPIs/CommonApi.cs
@@ -130,7 +130,7 @@ namespace Senparc.Weixin.Work.CommonAPIs
                 agentid = agentId
             };
 
-            return CommonJsonSend.Send<ConvertToOpenIdResult>(null, url, data, CommonJsonSendType.POST, timeOut);
+            return Senparc.Weixin.CommonAPIs.CommonJsonSend.Send<ConvertToOpenIdResult>(null, url, data, CommonJsonSendType.POST, timeOut);
         }
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace Senparc.Weixin.Work.CommonAPIs
                 openid = openId
             };
 
-            return CommonJsonSend.Send<ConvertToUserIdResult>(null, url, data, CommonJsonSendType.POST, timeOut);
+            return Senparc.Weixin.CommonAPIs.CommonJsonSend.Send<ConvertToUserIdResult>(null, url, data, CommonJsonSendType.POST, timeOut);
         }
         #endregion
 

--- a/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/RequestUtility.Get.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/RequestUtility.Get.cs
@@ -100,8 +100,10 @@ namespace Senparc.Weixin.HttpUtility
 
             var handler = new HttpClientHandler
             {
-                CookieContainer = cookieContainer ?? new CookieContainer(),
                 UseCookies = true,
+                CookieContainer = cookieContainer ?? new CookieContainer(),
+                UseProxy = _webproxy != null,
+                Proxy = _webproxy,
             };
 
             if (cer != null)
@@ -133,10 +135,14 @@ namespace Senparc.Weixin.HttpUtility
             wc.Encoding = encoding ?? Encoding.UTF8;
             return wc.DownloadString(url);
 #else
-            HttpClient httpClient = new HttpClient();
-            var t = httpClient.GetStringAsync(url);
-            t.Wait();
-            return t.Result;
+            var handler = new HttpClientHandler
+            {
+                UseProxy = _webproxy != null,
+                Proxy = _webproxy,
+            };
+
+            HttpClient httpClient = new HttpClient(handler);
+            return httpClient.GetStringAsync(url).Result;
 #endif
         }
 
@@ -175,9 +181,7 @@ namespace Senparc.Weixin.HttpUtility
 #else
 
             var httpClient = HttpGet_Common_NetCore(url, cookieContainer, encoding, cer, refererUrl, useAjax, timeOut);
-            var t = httpClient.GetStringAsync(url);
-            t.Wait();
-            return t.Result;
+            return httpClient.GetStringAsync(url).Result;
 #endif
         }
 
@@ -244,15 +248,19 @@ namespace Senparc.Weixin.HttpUtility
         /// <returns></returns>
         public static async Task<string> HttpGetAsync(string url, Encoding encoding = null)
         {
-
-
 #if NET35 || NET40 || NET45
             WebClient wc = new WebClient();
             wc.Proxy = _webproxy;
             wc.Encoding = encoding ?? Encoding.UTF8;
             return await wc.DownloadStringTaskAsync(url);
 #else
-            HttpClient httpClient = new HttpClient();
+            var handler = new HttpClientHandler
+            {
+                UseProxy = _webproxy != null,
+                Proxy = _webproxy,
+            };
+
+            HttpClient httpClient = new HttpClient(handler);
             return await httpClient.GetStringAsync(url);
 #endif
 

--- a/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/RequestUtility.Post.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/RequestUtility.Post.cs
@@ -97,7 +97,7 @@ namespace Senparc.Weixin.HttpUtility
                   new RemoteCertificateValidationCallback(CheckValidationResult);
             }
 
-            #region 处理Form表单文件上传
+        #region 处理Form表单文件上传
             var formUploadFile = fileDictionary != null && fileDictionary.Count > 0;//是否用Form上传文件
             if (formUploadFile)
             {
@@ -165,7 +165,7 @@ namespace Senparc.Weixin.HttpUtility
             {
                 request.ContentType = "application/x-www-form-urlencoded";
             }
-            #endregion
+        #endregion
 
             request.ContentLength = postStream != null ? postStream.Length : 0;
 
@@ -202,8 +202,13 @@ namespace Senparc.Weixin.HttpUtility
             Encoding encoding = null, X509Certificate2 cer = null, bool useAjax = false, int timeOut = Config.TIME_OUT,
             bool checkValidationResult = false)
         {
-            HttpClientHandler handler = new HttpClientHandler();
-            handler.CookieContainer = cookieContainer;
+            var handler = new HttpClientHandler()
+            {
+                UseProxy = _webproxy != null,
+                Proxy = _webproxy,
+                UseCookies = true,
+                CookieContainer = cookieContainer,
+            };
 
             if (checkValidationResult)
             {


### PR DESCRIPTION
1. In core version. Although **_webproxy** is defined, it's not used.
So, **RequestUtility.SetHttpProxy** will never do it's work correctly.
2. Replace **CommonJsonSend.Send** with  **Senparc.Weixin.CommonAPIs.CommonJsonSend.Send** in **CommonApi.cs**.
Because **CommonJsonSend.Send** is clearly defined as an obsolete function.

**_This pull request fixed the above problems._**