### PR TITLE
在Senparc.Weixin.MP.MvcExtension中提供EnableRequestRewind中间件

### DIFF
--- a/Samples/Senparc.Weixin.MP.Sample.vs2017/Senparc.Weixin.MP.CoreSample/Startup.cs
+++ b/Samples/Senparc.Weixin.MP.Sample.vs2017/Senparc.Weixin.MP.CoreSample/Startup.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -54,6 +55,9 @@ namespace Senparc.Weixin.MP.CoreSample
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, IOptions<SenparcWeixinSetting> senparcWeixinSetting)
         {
+            //引入EnableRequestRewind中间件
+            app.UseEnableRequestRewind();
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/src/Senparc.Weixin.MP.MvcExtension/Senparc.Weixin.MP.MvcExtension/Utilities/HttpUtility/EnableRequestRewind.cs
+++ b/src/Senparc.Weixin.MP.MvcExtension/Senparc.Weixin.MP.MvcExtension/Utilities/HttpUtility/EnableRequestRewind.cs
@@ -1,0 +1,33 @@
+#if NETSTANDARD2_0
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
+
+namespace Microsoft.AspNetCore.Http
+{
+    public class EnableRequestRewindMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public EnableRequestRewindMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            context.Request.EnableRewind();
+            await _next(context);
+        }
+    }
+
+    public static class EnableRequestRewindExtension
+    {
+        public static IApplicationBuilder UseEnableRequestRewind(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<EnableRequestRewindMiddleware>();
+        }
+    }
+}
+#endif

--- a/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/RequestUtility.Post.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/RequestUtility.Post.cs
@@ -272,9 +272,11 @@ namespace Senparc.Weixin.HttpUtility
             {
                 hc = new StreamContent(postStream);
 
-                //使用Url格式Form表单Post提交的时候才使用application/x-www-form-urlencoded
-                //hc.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
                 hc.Headers.ContentType = new MediaTypeHeaderValue("text/xml");
+
+                //使用Url格式Form表单Post提交的时候才使用application/x-www-form-urlencoded
+                //去掉注释以测试Request.Body为空的情况
+                //hc.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
             }
 
             //HttpContentHeader(hc, timeOut);


### PR DESCRIPTION
在Senparc.Weixin.MP.MvcExtension中提供EnableRequestRewind中间件，开启netcore2的RequestRewind模式令Request.Body可以二次读取，以解决某些特殊情况下netcore默认机制导致的Request.Body为空而引发的WeixinSDK错误的问题。#1090