### PR TITLE
修复.NetCore环境下的一个BUG

### DIFF
--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/ResponseHandler.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/ResponseHandler.cs
@@ -105,6 +105,7 @@ namespace Senparc.Weixin.MP.TenPayLibV3
 
         /// <summary>
         /// 获取页面提交的get和post参数
+	/// 注意:.NetCore环境必须传入HttpContext实例，不能传Null，这个接口调试特别困难，千万别出错！
         /// </summary>
         /// <param name="httpContext"></param>
         public ResponseHandler(HttpContext httpContext)
@@ -146,7 +147,11 @@ namespace Senparc.Weixin.MP.TenPayLibV3
 #else
             Parameters = new Hashtable();
 
-            HttpContext = httpContext ?? new DefaultHttpContext();
+            if(httpContext == null)
+            {
+                throw new Exception(".net core环境必须传入HttpContext的实例");
+            }
+            HttpContext = httpContext;
             //post data
             if (HttpContext.Request.Method.ToUpper() == "POST" && HttpContext.Request.HasFormContentType)
             {


### PR DESCRIPTION
在.NetCore环境下，ResponseHandler方法中，不能用new DefaultHttpContext()代替客户端请求时创建的HttpContext；
这个接口调试特别困难，千万别出错！