### PR TITLE
这句没用：resHandler.SetKey(TenPayV3Info.Key);

### DIFF
--- a/Samples/Senparc.Weixin.MP.Sample/Senparc.Weixin.MP.Sample/Controllers/TenPayV3Controller.cs
+++ b/Samples/Senparc.Weixin.MP.Sample/Senparc.Weixin.MP.Sample/Controllers/TenPayV3Controller.cs
@@ -399,13 +399,9 @@ namespace Senparc.Weixin.MP.Sample.Controllers
             try
             {
                 ResponseHandler resHandler = new ResponseHandler(null);
-
                 string return_code = resHandler.GetParameter("return_code");
                 string return_msg = resHandler.GetParameter("return_msg");
-
                 string res = null;
-
-                resHandler.SetKey(TenPayV3Info.Key);
                 //验证请求是否从微信发过来（安全）
                 if (resHandler.IsTenpaySign() && return_code.ToUpper() == "SUCCESS")
                 {


### PR DESCRIPTION
在这里没有用到这个Key，可以删掉，很多人都是抄DEMO的代码的，免得误导。
resHandler.SetKey(TenPayV3Info.Key);