### PR TITLE
示例代码参数传输错误

### DIFF
--- a/Samples/Senparc.Weixin.MP.Sample/Senparc.Weixin.MP.Sample/Controllers/TenPayV3Controller.cs
+++ b/Samples/Senparc.Weixin.MP.Sample/Senparc.Weixin.MP.Sample/Controllers/TenPayV3Controller.cs
@@ -340,7 +340,18 @@ namespace Senparc.Weixin.MP.Sample.Controllers
             //packageReqHandler.SetParameter("sign", sign);
 
             //string data = packageReqHandler.ParseXML();
-            var xmlDataInfo = new TenPayV3UnifiedorderRequestData(TenPayV3Info.AppId, TenPayV3Info.MchId, "test", sp_billno, 1, Request.UserHostAddress, TenPayV3Info.TenPayV3Notify, TenPayV3Type.NATIVE, productId, TenPayV3Info.Key, nonceStr);
+            var xmlDataInfo = new TenPayV3UnifiedorderRequestData(TenPayV3Info.AppId, 
+            TenPayV3Info.MchId, 
+            "test", 
+            sp_billno, 
+            1, 
+            Request.UserHostAddress, 
+            TenPayV3Info.TenPayV3Notify, 
+            TenPayV3Type.NATIVE, 
+            null,
+            TenPayV3Info.Key, 
+            nonceStr,
+            productId:productId);
             //调用统一订单接口
             var result = TenPayV3.Unifiedorder(xmlDataInfo);
             //var unifiedorderRes = XDocument.Parse(result);


### PR DESCRIPTION
trade_type=NATIVE时，OpenId应该为null，
示例代码中错误的把productId当作OpenId传进去了