### PR TITLE
Developer

### DIFF
--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/Media/MediaApi.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/Media/MediaApi.cs
@@ -1,4 +1,4 @@
-﻿#region Apache License Version 2.0
+#region Apache License Version 2.0
 /*----------------------------------------------------------------
 
 Copyright 2018 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
@@ -259,28 +259,47 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         }
 
         /// <summary>
-        /// 获取永久素材(除了图文)
+        /// 获取永久素材(除了图文、视频)
         /// </summary>
         /// <param name="accessTokenOrAppId">AccessToken或AppId（推荐使用AppId，需要先注册）</param>
         /// <param name="mediaId">要获取的素材的media_id</param>
-        public static GetForeverMediaVideoResultJson GetForeverMedia(string accessTokenOrAppId, string mediaId,int timeOut = Config.TIME_OUT)
+        /// <param name="stream">写入文件流</param>
+        public static WxJsonResult GetForeverMedia(string accessTokenOrAppId, string mediaId, Stream stream, int timeOut = Config.TIME_OUT)
         {
             return ApiHandlerWapper.TryCommonApi(accessToken =>
+            {
+                string urlFormat = string.Format(Config.ApiMpHost + "/cgi-bin/material/get_material?access_token={0}", (object)accessToken.AsUrlData());
+                var data = new
+                {
+                    media_id = mediaId
+                };
+
+                if (stream != null)
+                {
+                    stream.Seek(0, SeekOrigin.Begin);
+                    Post.Download(urlFormat, null, stream);
+                }
+                return new WxJsonResult() { errcode = ReturnCode.请求成功, errmsg = "ok" };//无实际意义
+            }, accessTokenOrAppId);
+        }
+
+        /// <summary>
+        /// 获取永久视频素材
+        /// </summary>
+        /// <param name="accessTokenOrAppId"></param>
+        /// <param name="mediaId"></param>
+        /// <param name="timeOut"></param>
+        /// <returns></returns>
+        public static GetForeverMediaVideoResultJson GetForeverVideo(string accessTokenOrAppId, string mediaId, int timeOut = Config.TIME_OUT)
+        {
+            return ApiHandlerWapper.TryCommonApi<GetForeverMediaVideoResultJson>(accessToken =>
             {
                 string url = Config.ApiMpHost + "/cgi-bin/material/get_material?access_token={0}";
                 var data = new
                 {
                     media_id = mediaId
                 };
-                var result = CommonJsonSend.Send<GetForeverMediaVideoResultJson>(accessToken, url, data, CommonJsonSendType.POST, timeOut: timeOut);
-
-                //if (stream != null)
-                //{
-                //    stream.Seek(0, SeekOrigin.Begin);
-                //    Post.Download(result.down_url, null, stream);
-                //}
-
-                return result;
+                return CommonJsonSend.Send<GetForeverMediaVideoResultJson>(accessToken, url, data, CommonJsonSendType.POST, timeOut: timeOut);
             }, accessTokenOrAppId);
         }
 
@@ -609,13 +628,39 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         }
 
         /// <summary>
-        /// 【异步方法】获取永久素材(除了图文)
+        /// 【异步方法】获取永久素材(除了图文、视频)
         /// </summary>
         /// <param name="accessTokenOrAppId">AccessToken或AppId（推荐使用AppId，需要先注册）</param>
         /// <param name="mediaId">要获取的素材的media_id</param>
-        public static async Task<GetForeverMediaVideoResultJson> GetForeverMediaAsync(string accessTokenOrAppId, string mediaId,int timeOut = Config.TIME_OUT)
+        public static async Task<WxJsonResult> GetForeverMediaAsync(string accessTokenOrAppId, string mediaId,Stream stream, int timeOut = Config.TIME_OUT)
         {
 
+            return await ApiHandlerWapper.TryCommonApiAsync(async accessToken =>
+            {
+                string urlFormat = string.Format(Config.ApiMpHost + "/cgi-bin/material/get_material?access_token={0}", (object)accessToken.AsUrlData());
+                var data = new
+                {
+                    media_id = mediaId
+                };
+
+                if (stream != null)
+                {
+                    stream.Seek(0, SeekOrigin.Begin);
+                    await Post.DownloadAsync(urlFormat, null, stream);
+                }
+                return new WxJsonResult() { errcode = ReturnCode.请求成功, errmsg = "ok" };//无实际意义
+            }, accessTokenOrAppId);
+        }
+
+        /// <summary>
+        /// 获取永久视频素材
+        /// </summary>
+        /// <param name="accessTokenOrAppId"></param>
+        /// <param name="mediaId"></param>
+        /// <param name="timeOut"></param>
+        /// <returns></returns>
+        public static async Task<GetForeverMediaVideoResultJson> GetForeverVideoAsync(string accessTokenOrAppId, string mediaId, int timeOut = Config.TIME_OUT)
+        {
             return await ApiHandlerWapper.TryCommonApiAsync(async accessToken =>
             {
                 string url = Config.ApiMpHost + "/cgi-bin/material/get_material?access_token={0}";
@@ -623,14 +668,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
                 {
                     media_id = mediaId
                 };
-                var result = CommonJsonSend.Send<GetForeverMediaVideoResultJson>(accessToken, url, data, CommonJsonSendType.POST, timeOut: timeOut);
-
-                //if (stream != null)
-                //{
-                //    stream.Seek(0, SeekOrigin.Begin);
-                //    await Post.DownloadAsync(result.down_url, null, stream);
-                //}
-
+                var result = await Senparc.Weixin.CommonAPIs.CommonJsonSend.SendAsync<GetForeverMediaVideoResultJson>(accessToken, url, data, CommonJsonSendType.POST, timeOut: timeOut);
                 return result;
             }, accessTokenOrAppId);
         }

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/User/UserApi.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/User/UserApi.cs
@@ -1,4 +1,4 @@
-﻿#region Apache License Version 2.0
+#region Apache License Version 2.0
 /*----------------------------------------------------------------
 
 Copyright 2018 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
@@ -147,6 +147,66 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
                 return CommonJsonSend.Send<BatchGetUserInfoJsonResult>(accessToken, url, data, timeOut: timeOut);
             }, accessTokenOrAppId);
         }
+
+        /// <summary>
+        /// 获取黑名单
+        /// </summary>
+        /// <param name="accessTokenOrAppId"></param>
+        /// <param name="beginOpenId"></param>
+        /// <param name="timeOut"></param>
+        /// <returns></returns>
+        public static OpenIdResultJson GetBlackList(string accessTokenOrAppId, string beginOpenId, int timeOut = Config.TIME_OUT)
+        {
+            return ApiHandlerWapper.TryCommonApi<OpenIdResultJson>(accessToken =>
+            {
+                string url = string.Format(Config.ApiMpHost + "/cgi-bin/tags/members/getblacklist?access_token={0}", accessToken.AsUrlData());
+                var data = new
+                {
+                    begin_openid = beginOpenId
+                };
+                return CommonJsonSend.Send<OpenIdResultJson>(accessToken, url, data, timeOut: timeOut);
+            }, accessTokenOrAppId, true);
+        }
+
+        /// <summary>
+        /// 取消拉黑用户
+        /// </summary>
+        /// <param name="accessTokenOrAppId"></param>
+        /// <param name="openidList"></param>
+        /// <param name="timeOut"></param>
+        /// <returns></returns>
+        public static WxJsonResult BatchUnBlackList(string accessTokenOrAppId, List<string> openidList, int timeOut = Config.TIME_OUT)
+        {
+            return ApiHandlerWapper.TryCommonApi<OpenIdResultJson>(accessToken =>
+            {
+                string urlFormat = string.Format(Config.ApiMpHost + "/cgi-bin/tags/members/batchunblacklist?access_token={0}", accessToken.AsUrlData());
+                var data = new
+                {
+                    openid_list = openidList
+                };
+                return CommonJsonSend.Send<OpenIdResultJson>(accessToken, urlFormat, data, timeOut: timeOut);
+            }, accessTokenOrAppId, true);
+        }
+
+        /// <summary>
+        /// 拉黑用户
+        /// </summary>
+        /// <param name="accessTokenOrAppId"></param>
+        /// <param name="openidList"></param>
+        /// <param name="timeOut"></param>
+        /// <returns></returns>
+        public static WxJsonResult BatchBlackList(string accessTokenOrAppId, List<string> openidList, int timeOut = Config.TIME_OUT)
+        {
+            return ApiHandlerWapper.TryCommonApi<OpenIdResultJson>(accessToken =>
+            {
+                string urlFormat = string.Format(Config.ApiMpHost + "/cgi-bin/tags/members/batchblacklist?access_token={0}", accessToken.AsUrlData());
+                var data = new
+                {
+                    openid_list = openidList
+                };
+                return CommonJsonSend.Send<OpenIdResultJson>(accessToken, urlFormat, data, timeOut: timeOut);
+            }, accessTokenOrAppId, true);
+        }
         #endregion
 
 #if !NET35 && !NET40
@@ -233,6 +293,66 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
                 };
                 return await Senparc.Weixin.CommonAPIs.CommonJsonSend.SendAsync<BatchGetUserInfoJsonResult>(accessToken, url, data, timeOut: timeOut);
             }, accessTokenOrAppId);
+        }
+
+        /// <summary>
+        /// 获取黑名单
+        /// </summary>
+        /// <param name="accessTokenOrAppId">AccessToken或AppId（推荐使用AppId，需要先注册）</param>
+        /// <param name="beginOpenId">当 begin_openid 为空时，默认从开头拉取。</param>
+        /// <param name="timeOut"></param>
+        /// <returns>每次调用最多可拉取 10000 个OpenID</returns>
+        public static async Task<OpenIdResultJson> GetBlackListAsync(string accessTokenOrAppId, string beginOpenId, int timeOut = Config.TIME_OUT)
+        {
+            return await ApiHandlerWapper.TryCommonApiAsync<OpenIdResultJson>(async accessToken =>
+            {
+                string url = string.Format(Config.ApiMpHost + "/cgi-bin/tags/members/getblacklist?access_token={0}", accessToken.AsUrlData());
+                var data = new
+                {
+                    begin_openid = beginOpenId
+                };
+                return await Senparc.Weixin.CommonAPIs.CommonJsonSend.SendAsync<OpenIdResultJson>(accessToken, url, data, timeOut: timeOut);
+            }, accessTokenOrAppId, true);
+        }
+
+        /// <summary>
+        /// 取消拉黑用户
+        /// </summary>
+        /// <param name="accessTokenOrAppId">AccessToken或AppId（推荐使用AppId，需要先注册）</param>
+        /// <param name="openidList">需要移除黑名单的用户的openid，一次移除最多允许20个</param>
+        /// <param name="timeOut"></param>
+        /// <returns></returns>
+        public static async Task<WxJsonResult> BatchUnBlackListAsync(string accessTokenOrAppId, List<string> openidList, int timeOut = Config.TIME_OUT)
+        {
+            return await ApiHandlerWapper.TryCommonApiAsync<OpenIdResultJson>(async accessToken =>
+            {
+                string urlFormat = string.Format(Config.ApiMpHost + "/cgi-bin/tags/members/batchunblacklist?access_token={0}", accessToken.AsUrlData());
+                var data = new
+                {
+                    openid_list = openidList
+                };
+                return await Senparc.Weixin.CommonAPIs.CommonJsonSend.SendAsync<OpenIdResultJson>(accessToken, urlFormat, data, timeOut: timeOut);
+            }, accessTokenOrAppId, true);
+        }
+
+        /// <summary>
+        /// 拉黑用户
+        /// </summary>
+        /// <param name="accessTokenOrAppId">AccessToken或AppId（推荐使用AppId，需要先注册）</param>
+        /// <param name="openidList">需要拉入黑名单的用户的openid，一次拉黑最多允许20个</param>
+        /// <param name="timeOut"></param>
+        /// <returns></returns>
+        public static async Task<WxJsonResult> BatchBlackListAsync(string accessTokenOrAppId, List<string> openidList, int timeOut = Config.TIME_OUT)
+        {
+            return await ApiHandlerWapper.TryCommonApiAsync<OpenIdResultJson>(async accessToken =>
+            {
+                string urlFormat = string.Format(Config.ApiMpHost + "/cgi-bin/tags/members/batchblacklist?access_token={0}", accessToken.AsUrlData());
+                var data = new
+                {
+                    openid_list = openidList
+                };
+                return await Senparc.Weixin.CommonAPIs.CommonJsonSend.SendAsync<OpenIdResultJson>(accessToken, urlFormat, data, timeOut: timeOut);
+            }, accessTokenOrAppId, true);
         }
         #endregion
 #endif


### PR DESCRIPTION
1. 添加黑名单管理
2. 分离永久视频素材获取接口

获取永久素材3种情况

图文 { "news_item": [ { "title":TITLE, "thumb_media_id"::THUMB_MEDIA_ID, "show_cover_pic":SHOW_COVER_PIC(0/1), "author":AUTHOR, "digest":DIGEST, "content":CONTENT, "url":URL, "content_source_url":CONTENT_SOURCE_URL }, //多图文消息有多篇文章 ] }
视频 { "title":TITLE, "description":DESCRIPTION, "down_url":DOWN_URL, }
其他 响应的直接为素材的内容，开发者可以自行保存为文件