### PR TITLE
Migrate from ASP.NET Core 2.0 to 2.1

### DIFF
--- a/Samples/Senparc.Weixin.MP.Sample.vs2017/Senparc.Weixin.MP.CoreSample/Program.cs
+++ b/Samples/Senparc.Weixin.MP.Sample.vs2017/Senparc.Weixin.MP.CoreSample/Program.cs
@@ -14,12 +14,11 @@ namespace Senparc.Weixin.MP.CoreSample
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+           CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .Build();
+                .UseStartup<Startup>();
     }
 }


### PR DESCRIPTION
Changes to take advantage of the new code-based idioms that are recommended in ASP.NET Core 2.1