### PR TITLE
解决.NetCore环境微信支付回调时ResponseHandler传入HttpContext实例后解析xml提示找不到根节点的错误.

### DIFF
--- a/Samples/Senparc.Weixin.MP.Sample.vs2017/Senparc.Weixin.MP.CoreSample/Controllers/TenPayV3Controller.cs
+++ b/Samples/Senparc.Weixin.MP.Sample.vs2017/Senparc.Weixin.MP.CoreSample/Controllers/TenPayV3Controller.cs
@@ -438,7 +438,7 @@ namespace Senparc.Weixin.MP.CoreSample.Controllers
         {
             try
             {
-                ResponseHandler resHandler = new ResponseHandler(null);
+                ResponseHandler resHandler = new ResponseHandler(HttpContext);
 
                 string return_code = resHandler.GetParameter("return_code");
                 string return_msg = resHandler.GetParameter("return_msg");

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/ResponseHandler.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/ResponseHandler.cs
@@ -176,7 +176,11 @@ namespace Senparc.Weixin.MP.TenPayLibV3
             if (HttpContext.Request.ContentLength > 0)
             {
                 var xmlDoc = new XmlDocument();
-                xmlDoc.Load(HttpContext.Request.Body);
+                //xmlDoc.Load(HttpContext.Request.Body);
+                using (var reader = new System.IO.StreamReader(HttpContext.Request.Body))
+                {
+                    xmlDoc.Load(reader);
+                }
                 var root = xmlDoc.SelectSingleNode("xml");
 
                 foreach (XmlNode xnf in root.ChildNodes)


### PR DESCRIPTION

解决.NetCore环境微信支付回调时ResponseHandler传入HttpContext实例后解析xml提示找不到根节点的错误.