### PR TITLE
国外爆出的XXE安全漏洞，以及 微信支付团队的说明如下：

### DIFF
--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLib/ClientResponseHandler.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLib/ClientResponseHandler.cs
@@ -84,6 +84,7 @@ namespace Senparc.Weixin.MP.TenPayLib
         {
             this.Content = content;
             XmlDocument xmlDoc = new XmlDocument();
+            xmlDoc.XmlResolver = null;
             xmlDoc.LoadXml(content);
             XmlNode root = xmlDoc.SelectSingleNode("root");
             XmlNodeList xnl = root.ChildNodes;

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLib/ResponseHandler.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLib/ResponseHandler.cs
@@ -149,6 +149,7 @@ namespace Senparc.Weixin.MP.TenPayLib
             if (this.HttpContext.Request.InputStream.Length > 0)
             {
                 XmlDocument xmlDoc = new XmlDocument();
+                xmlDoc.XmlResolver = null;
                 xmlDoc.Load(this.HttpContext.Request.InputStream);
                 XmlNode root = xmlDoc.SelectSingleNode("xml");
                 XmlNodeList xnl = root.ChildNodes;
@@ -182,6 +183,7 @@ namespace Senparc.Weixin.MP.TenPayLib
             if (this.HttpContext.Request.Body.Length > 0)
             {
                 XmlDocument xmlDoc = new XmlDocument();
+                xmlDoc.XmlResolver = null;
                 xmlDoc.Load(this.HttpContext.Request.Body);
                 XmlNode root = xmlDoc.SelectSingleNode("xml");
                 XmlNodeList xnl = root.ChildNodes;

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/ResponseHandler.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/ResponseHandler.cs
@@ -141,6 +141,7 @@ namespace Senparc.Weixin.MP.TenPayLibV3
             if (this.HttpContext.Request.InputStream.Length > 0)
             {
                 XmlDocument xmlDoc = new XmlDocument();
+                xmlDoc.XmlResolver = null;
                 xmlDoc.Load(this.HttpContext.Request.InputStream);
                 XmlNode root = xmlDoc.SelectSingleNode("xml");
                 XmlNodeList xnl = root.ChildNodes;
@@ -176,6 +177,7 @@ namespace Senparc.Weixin.MP.TenPayLibV3
             if (HttpContext.Request.ContentLength > 0)
             {
                 var xmlDoc = new XmlDocument();
+                xmlDoc.XmlResolver = null;
                 //xmlDoc.Load(HttpContext.Request.Body);
                 using (var reader = new System.IO.StreamReader(HttpContext.Request.Body))
                 {

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/TenPayV3Api/RedPackApi/RedPackApi.Via.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/TenPayV3Api/RedPackApi/RedPackApi.Via.cs
@@ -153,7 +153,7 @@ namespace Senparc.Weixin.MP.TenPayLibV3
             X509Certificate2 cer = new X509Certificate2(cert, password, X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.MachineKeySet);
 
             XmlDocument doc = new XmlDocument();
-
+            doc.XmlResolver = null;
             #region 发起post请求，载入到doc中
 
 #if NET35 || NET40 || NET45 || NET461

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/TenPayV3Api/RedPackApi/RedPackApi.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/TenPayV3Api/RedPackApi/RedPackApi.cs
@@ -197,6 +197,7 @@ PROCESSING	请求已受理，请稍后使用原单号查询发放结果	二十�
             X509Certificate2 cer = new X509Certificate2(cert, password, X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.MachineKeySet);
 
             XmlDocument doc = new XmlDocument();
+            doc.XmlResolver = null;
 
 #if NET35 || NET40 || NET45 || NET461
             ServicePointManager.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback(CheckValidationResult);
@@ -425,6 +426,7 @@ PROCESSING	请求已受理，请稍后使用原单号查询发放结果	二十�
             X509Certificate2 cer = new X509Certificate2(cert, password, X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.MachineKeySet);
 
             XmlDocument doc = new XmlDocument();
+            doc.XmlResolver = null;
 
             #region 发起post请求，载入到doc中
 
@@ -598,6 +600,7 @@ PROCESSING	请求已受理，请稍后使用原单号查询发放结果	二十�
             X509Certificate2 cer = new X509Certificate2(cert, password, X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.MachineKeySet);
 
             XmlDocument doc = new XmlDocument();
+            doc.XmlResolver = null;
             #region 发起post请求，载入到doc中
 
 #if NET35 || NET40 || NET45 || NET461

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Tencent/Sample.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Tencent/Sample.cs
@@ -68,6 +68,7 @@ namespace MsgCryptTest
              * 将sEncryptMsg解密看看是否是原文
              * */
             XmlDocument doc = new XmlDocument();
+            doc.XmlResolver = null;
             doc.LoadXml(sEncryptMsg);
             XmlNode root = doc.FirstChild;
             string sig = root["MsgSignature"].InnerText;

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Tencent/WXBizMsgCrypt.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Tencent/WXBizMsgCrypt.cs
@@ -94,6 +94,7 @@ namespace Senparc.Weixin.MP.Tencent
                 return (int)WXBizMsgCryptErrorCode.WXBizMsgCrypt_IllegalAesKey;
             }
             XmlDocument doc = new XmlDocument();
+            doc.XmlResolver = null;
             XmlNode root;
             string sEncryptMsg;
             try

--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/Tencent/Sample.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/Tencent/Sample.cs
@@ -67,6 +67,7 @@ namespace MsgCryptTest
              * 将sEncryptMsg解密看看是否是原文
              * */
             XmlDocument doc = new XmlDocument();
+            doc.XmlResolver = null;
             doc.LoadXml(sEncryptMsg);
             XmlNode root = doc.FirstChild;
             string sig = root["MsgSignature"].InnerText;

--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/Tencent/WXBizMsgCrypt.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/Tencent/WXBizMsgCrypt.cs
@@ -63,6 +63,7 @@ namespace Senparc.Weixin.Open.Tencent
 				return (int)WXBizMsgCryptErrorCode.WXBizMsgCrypt_IllegalAesKey;
 			}
             XmlDocument doc = new XmlDocument();
+            doc.XmlResolver = null;
             XmlNode root;
             string sEncryptMsg;
             try

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/TenPayLib/ResponseHandler.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/TenPayLib/ResponseHandler.cs
@@ -121,6 +121,7 @@ namespace Senparc.Weixin.Work.TenPayLib
 			if (this.HttpContext.Request.InputStream.Length > 0)
 			{
 				XmlDocument xmlDoc = new XmlDocument();
+                xmlDoc.XmlResolver = null;
 				xmlDoc.Load(this.HttpContext.Request.InputStream);
 				XmlNode root = xmlDoc.SelectSingleNode("xml");
 				XmlNodeList xnl = root.ChildNodes;
@@ -162,6 +163,7 @@ namespace Senparc.Weixin.Work.TenPayLib
             if (this.HttpContext.Request.Body.Length > 0)
             {
                 XmlDocument xmlDoc = new XmlDocument();
+                xmlDoc.XmlResolver = null;
                 xmlDoc.Load(this.HttpContext.Request.Body);
                 XmlNode root = xmlDoc.SelectSingleNode("xml");
                 XmlNodeList xnl = root.ChildNodes;

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Tencent/Sample.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Tencent/Sample.cs
@@ -92,6 +92,7 @@ namespace MsgCryptTest
              * 将sEncryptMsg解密看看是否是原文
              * */
             XmlDocument doc = new XmlDocument();
+            doc.XmlResolver = null;
             doc.LoadXml(sEncryptMsg);
             XmlNode root = doc.FirstChild;
             string sig = root["MsgSignature"].InnerText;

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Tencent/WXBizMsgCrypt.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Tencent/WXBizMsgCrypt.cs
@@ -111,6 +111,7 @@ namespace Senparc.Weixin.Work.Tencent
                 return (int)WXBizMsgCryptErrorCode.WXBizMsgCrypt_IllegalAesKey;
             }
             XmlDocument doc = new XmlDocument();
+            doc.XmlResolver = null;
             XmlNode root;
             string sEncryptMsg;
             try

--- a/src/Senparc.Weixin.WxOpen/src/Senparc.Weixin.WxOpen/Senparc.Weixin.WxOpen/Tencent/WXBizMsgCrypt.cs
+++ b/src/Senparc.Weixin.WxOpen/src/Senparc.Weixin.WxOpen/Senparc.Weixin.WxOpen/Tencent/WXBizMsgCrypt.cs
@@ -94,6 +94,7 @@ namespace Senparc.Weixin.WxOpen.Tencent
 				return (int)WXBizMsgCryptErrorCode.WXBizMsgCrypt_IllegalAesKey;
 			}
             XmlDocument doc = new XmlDocument();
+            doc.XmlResolver = null;
             XmlNode root;
             string sEncryptMsg;
             try


### PR DESCRIPTION
https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=23_5
根据说明,将所有XmlDocument的地方
var xmlDoc = new XmlDocument();
xmlDoc.XmlResolver = null; // 添加这一行代码