### PR TITLE
微信支付现已支持HMAC-SHA256签名方式

### DIFF
--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/Entities/Request/TenPayV3MicroPayRequestData.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/Entities/Request/TenPayV3MicroPayRequestData.cs
@@ -172,7 +172,14 @@ namespace Senparc.Weixin.MP.TenPayLibV3
             PackageRequestHandler.SetParameter("spbill_create_ip", this.SpbillCreateIp); //终端IP
             PackageRequestHandler.SetParameter("goods_tag", this.GoodsTag); //商品标记
             PackageRequestHandler.SetParameter("auth_code", this.AuthCode); //授权码
-            Sign = PackageRequestHandler.CreateMd5Sign("key", this.Key);
+
+            // TODO:★554393109 修改
+            //***************************************************************************************
+            Sign = "MD5".Equals(signType, System.StringComparison.OrdinalIgnoreCase) 
+                ? PackageRequestHandler.CreateMd5Sign("key", this.Key) 
+                : PackageRequestHandler.CreateSha256Sign("key", this.Key);
+            //***************************************************************************************
+
             PackageRequestHandler.SetParameter("sign", Sign); //签名
 
             #endregion

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/RequestHandler.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/TenPayLibV3/RequestHandler.cs
@@ -92,7 +92,7 @@ namespace Senparc.Weixin.MP.TenPayLibV3
         {
             Parameters = new Hashtable();
 #if NET35 || NET40 || NET45 || NET461
-			this.HttpContext = httpContext ?? HttpContext.Current;
+            this.HttpContext = httpContext ?? HttpContext.Current;
 #else
             this.HttpContext = httpContext ?? new DefaultHttpContext();
 #endif
@@ -213,6 +213,56 @@ namespace Senparc.Weixin.MP.TenPayLibV3
 
             return sign;
         }
+
+
+
+
+
+        // TODO:★554393109 修改
+        //***************************************************************************************
+        /// <summary>
+        /// 创建sha256摘要,规则是:按参数名称a-z排序,遇到空值的参数不参加签名
+        /// </summary>
+        /// <param name="key">参数名</param>
+        /// <param name="value">参数值</param>
+        /// key和value通常用于填充最后一组参数
+        /// <returns></returns>
+        public virtual string CreateSha256Sign(string key, string value)
+        {
+            var sb = new StringBuilder();
+
+            var akeys = new ArrayList(Parameters.Keys);
+            akeys.Sort(ASCIISort.Create());
+
+            foreach (string k in akeys)
+            {
+                string v = (string)Parameters[k];
+                if (null != v && "".CompareTo(v) != 0
+                    && "sign".CompareTo(k) != 0
+                    //&& "sign_type".CompareTo(k) != 0
+                    && "key".CompareTo(k) != 0)
+                {
+                    sb.Append(k + "=" + v + "&");
+                }
+            }
+
+            sb.Append(key + "=" + value);
+
+            //string sign = EncryptHelper.GetMD5(sb.ToString(), GetCharset()).ToUpper();
+
+            //编码强制使用UTF8：https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=4_1
+
+            // 现支持HMAC-SHA256签名方式（EncryptHelper.GetHmacSha256方法留待实现）
+            // https://pay.weixin.qq.com/wiki/doc/api/micropay.php?chapter=4_3
+            string sign = EncryptHelper.GetHmacSha256(sb.ToString(), "UTF-8").ToUpper();
+
+            return sign;
+        }
+        //***************************************************************************************
+
+
+
+
 
         /// <summary>
         /// 输出XML


### PR DESCRIPTION
微信支付现支持HMAC-SHA256签名方式（EncryptHelper.GetHmacSha256方法留待实现）

https://pay.weixin.qq.com/wiki/doc/api/micropay.php?chapter=4_3

**添加 Senparc.Weixin.MP.TenPayLibV3.RequestHandler.CreateSha256Sign(string key, string value) 方法**

**修改 Senparc.Weixin.MP.TenPayLibV3.TenPayV3MicroPayRequestData 构造函数中 Sign签名方式，添加Sha256**

其余支付实体对象同理修改

Signed-off-by: 554393109 <554393109@qq.com>