### PR TITLE
fix 'dotnet build' command error for net35

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+version: 1.0.0.{build}
+image:
+  - Visual Studio 2017
+pull_requests:
+  do_not_increment_build_number: true
+branches:
+  only:
+    - master
+skip_branch_with_pr: true
+configuration: Release
+before_build:
+  - cmd: dotnet restore Samples\Senparc.Weixin.MP.Sample.vs2017\Senparc.Weixin.MP.Sample.vs2017.sln
+build:
+  verbosity: minimal
+  parallel: true
+build_script:
+  - cmd: dotnet build -c Release Samples\Senparc.Weixin.MP.Sample.vs2017\Senparc.Weixin.MP.Sample.vs2017.sln
+#test_script:
+#  - cmd: dotnet test -c Release Samples\Senparc.Weixin.MP.Sample.vs2017\Senparc.Weixin.MP.Sample.vs2017.sln
+artifacts:
+  - path: '**\*.nupkg'
+nuget:
+  disable_publish_on_pr: true
+#deploy:
+#  provider: NuGet
+#  api_key:
+#    secure: <Your secret>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,6 +4,7 @@
     <DebugType Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">full</DebugType>
     <DebugType Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">portable</DebugType>
     <IncludeSymbols>True</IncludeSymbols>
+    <Net35FrameworkPathOverride>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client;$(WINDIR)\Microsoft.NET\Framework\v2.0.50727</Net35FrameworkPathOverride>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/CommonAPIs/Menu/CommonApi.Menu.Custom.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/CommonAPIs/Menu/CommonApi.Menu.Custom.cs
@@ -64,7 +64,7 @@ using System.Threading.Tasks;
 using Senparc.Weixin.CommonAPIs;
 using Senparc.CO2NET.Helpers;
 
-#if NET35 || NET40 || NET45
+#if NET40 || NET45
 using System.Web.Script.Serialization;
 #endif
 
@@ -237,7 +237,7 @@ namespace Senparc.Weixin.MP.CommonAPIs
                 try
                 {
 
-#if NET35 || NET40 || NET45
+#if NET40 || NET45
                     JavaScriptSerializer js = new JavaScriptSerializer();
                     var jsonResult = js.Deserialize<GetMenuResultFull>(jsonString);
 #else

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Senparc.Weixin.MP.vs2017.csproj
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Senparc.Weixin.MP.vs2017.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net35;net40;net45;netstandard2.0</TargetFrameworks>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(Net35FrameworkPathOverride)</FrameworkPathOverride>
     <Version>16.6.15</Version>
     <AssemblyName>Senparc.Weixin.MP</AssemblyName>
     <RootNamespace>Senparc.Weixin.MP</RootNamespace>

--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/Senparc.Weixin.Open.vs2017.csproj
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/Senparc.Weixin.Open.vs2017.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net35;net40;net45;netstandard2.0</TargetFrameworks>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(Net35FrameworkPathOverride)</FrameworkPathOverride>
     <Version>4.4.5.2</Version>
     <AssemblyName>Senparc.Weixin.Open</AssemblyName>
     <RootNamespace>Senparc.Weixin.Open</RootNamespace>

--- a/src/Senparc.Weixin.TenPay/Senparc.Weixin.TenPay/Senparc.Weixin.TenPay.vs2017.csproj
+++ b/src/Senparc.Weixin.TenPay/Senparc.Weixin.TenPay/Senparc.Weixin.TenPay.vs2017.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net35;net40;net45;netstandard2.0</TargetFrameworks>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(Net35FrameworkPathOverride)</FrameworkPathOverride>
     <Version>1.2.1</Version>
     <AssemblyName>Senparc.Weixin.TenPay</AssemblyName>
     <RootNamespace>Senparc.Weixin.TenPay</RootNamespace>

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Senparc.Weixin.Work.vs2017.csproj
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Senparc.Weixin.Work.vs2017.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net35;net40;net45;netstandard2.0</TargetFrameworks>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(Net35FrameworkPathOverride)</FrameworkPathOverride>
 		<Version>3.3.10.1</Version>
 		<AssemblyName>Senparc.Weixin.Work</AssemblyName>
 		<RootNamespace>Senparc.Weixin.Work</RootNamespace>

--- a/src/Senparc.Weixin/Senparc.Weixin/Senparc.Weixin.vs2017.csproj
+++ b/src/Senparc.Weixin/Senparc.Weixin/Senparc.Weixin.vs2017.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net35;net40;net45;netstandard2.0</TargetFrameworks>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(Net35FrameworkPathOverride)</FrameworkPathOverride>
     <Version>6.3.11</Version>
     <AssemblyName>Senparc.Weixin</AssemblyName>
     <RootNamespace>Senparc.Weixin</RootNamespace>

--- a/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/Get.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/Get.cs
@@ -59,20 +59,15 @@ Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
 
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
 #if !NET35 && !NET40
 using System.Net.Http;
 using System.Threading.Tasks;
 #endif
-using System.Text;
-#if NET35 || NET40 || NET45
+#if NET40 || NET45
 using System.Web.Script.Serialization;
 #endif
 using Senparc.Weixin.Entities;
 using Senparc.Weixin.Exceptions;
-using System.Text.RegularExpressions;
 
 namespace Senparc.Weixin.HttpUtility
 {

--- a/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/Post.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/Utilities/HttpUtility/Post.cs
@@ -55,18 +55,11 @@ Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
 
 
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading.Tasks;
+using Senparc.CO2NET.Helpers;
 using Senparc.Weixin.Entities;
 using Senparc.Weixin.Exceptions;
-using Senparc.CO2NET.Helpers;
 
-#if NET35 || NET40 || NET45
+#if NET40 || NET45
 using System.Web.Script.Serialization;
 using Senparc.Weixin.HttpUtility;
 #endif


### PR DESCRIPTION
error MSB3644: The reference assemblies for framework ".NETFramework,Version=v3.5" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.