### PR TITLE
JsCode2Json返回结果增加unionid

### DIFF
--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/Sns/SnsJson/JsCode2JsonResult.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/Sns/SnsJson/JsCode2JsonResult.cs
@@ -27,6 +27,7 @@ Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
     
     创建标识：Senparc - 20170827
 
+
 ----------------------------------------------------------------*/
 using System;
 using System.Collections.Generic;
@@ -50,5 +51,9 @@ namespace Senparc.Weixin.Open.WxaAPIs.Sns
         /// 会话密钥
         /// </summary>
         public string session_key { get; set; }
+        /// <summary>
+        /// 用户在开放平台的唯一标识符，在满足 UnionID 下发条件的情况下会返回
+        /// </summary>
+        public string unionid { get; set; }
     }
 }


### PR DESCRIPTION
JsCode2Json的返回结果，在小程序有绑定开放平台帐号的情况下，是有返回unionid的。

> [[[接口调用]]]
[2019/05/24 10:58:10.6071]
[线程：36]
	URL：https://api.weixin.qq.com/sns/component/jscode2session?appid=wx259b2a*****&js_code=001w1foa0ovPmz13****&grant_type=authorization_code&component_appid=wxd39ba81******&component_access_token=****
	Result：
{"session_key":"IT7jqiSiKcaOkZjmU*****","openid":"o52fN4vsICxqiZTdOzhd6Vol****","unionid":"oqDIW5sx4oTQIBpeUJXcojuR****"}