### PR TITLE
回复评论的参数bug，图文群发总数据的新字段添加

### DIFF
--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/Analysis/AnalysisResultJson/ArticleAnalysisItemJson.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/Analysis/AnalysisResultJson/ArticleAnalysisItemJson.cs
@@ -113,6 +113,14 @@ namespace Senparc.Weixin.MP.AdvancedAPIs.Analysis
         /// 图文消息的标题
         /// </summary>
         public string title { get; set; }
+        /// <summary>
+        /// 图文消息链接
+        /// </summary>
+        public string url { get; set; }
+        /// <summary>
+        /// 在获取图文阅读分时数据时才有该字段，代表用户从哪里进入来阅读该图文。0:会话;1.好友;2.朋友圈;3.腾讯微博;4.历史消息页;5.其他;6.看一看;7.搜一搜
+        /// </summary>
+        public int user_source { get; set; }
 
         public List<ArticleTotal_Detail> details { get; set; }
     }

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/Comment/CommentApi.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/Comment/CommentApi.cs
@@ -271,6 +271,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
                     msg_data_id = msg_data_id,
                     index = index,
                     user_comment_id = user_comment_id,
+                    content = content
                 };
 
                 JsonSetting jsonSetting = new JsonSetting(ignoreNulls: true);
@@ -289,7 +290,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         /// <param name="timeOut"></param>
         /// <returns></returns>
         [ApiBind(NeuChar.PlatformType.WeChat_OfficialAccount, "CommentApi.ReplyDelete", true)]
-        public static WxJsonResult ReplyDelete(string accessTokenOrAppId, uint msg_data_id, uint? index, uint user_comment_id, string content, int timeOut = Config.TIME_OUT)
+        public static WxJsonResult ReplyDelete(string accessTokenOrAppId, uint msg_data_id, uint? index, uint user_comment_id, int timeOut = Config.TIME_OUT)
         {
             return ApiHandlerWapper.TryCommonApi(accessToken =>
             {
@@ -514,6 +515,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
                     msg_data_id = msg_data_id,
                     index = index,
                     user_comment_id = user_comment_id,
+                    content = content
                 };
 
                 JsonSetting jsonSetting = new JsonSetting(ignoreNulls: true);
@@ -532,7 +534,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         /// <param name="timeOut"></param>
         /// <returns></returns>
         [ApiBind(NeuChar.PlatformType.WeChat_OfficialAccount, "CommentApi.ReplyDeleteAsync", true)]
-        public static Task<WxJsonResult> ReplyDeleteAsync(string accessTokenOrAppId, uint msg_data_id, uint? index, uint user_comment_id, string content, int timeOut = Config.TIME_OUT)
+        public static Task<WxJsonResult> ReplyDeleteAsync(string accessTokenOrAppId, uint msg_data_id, uint? index, uint user_comment_id, int timeOut = Config.TIME_OUT)
         {
             return ApiHandlerWapper.TryCommonApiAsync(async accessToken =>
            {


### PR DESCRIPTION
### 评论回复
1.  添加回复时content内容未传给微信
2. 删除回复时不需要传输content参数

### 添加图文群发总数据的新字段
```
        {
            "ref_date": "2019-07-03",
            "msgid": "2650799822_1",
            "title": " 你会怎么安排孩子的假期？",
            "user_source": 0,
            "details": [
               ...
            ],
            "url": "https:\/\/mp.weixin.qq.com\/s?__biz=MjM5OTI2MjA2MQ==&mid=2650799822&idx=1&sn=633ddcf0b0b8a4af2b151fbd17e0cfe3#rd"
        },
```