### PR TITLE
卡券WxCardApiTicketContainer【异步方法】获取可用Ticket,type传值的问题

### DIFF
--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Containers/WxCardApiTicketContainer.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Containers/WxCardApiTicketContainer.cs
@@ -314,7 +314,7 @@ namespace Senparc.Weixin.MP.Containers
                 {
                     //已过期，重新获取
                     JsApiTicketResult wxCardApiTicketResult = await CommonApi.GetTicketAsync(wxCardApiTicketBag.AppId,
-                                                                                             wxCardApiTicketBag.AppSecret).ConfigureAwait(false);
+                                                                                             wxCardApiTicketBag.AppSecret,"wx_card").ConfigureAwait(false);
 
                     wxCardApiTicketBag.WxCardApiTicketResult = wxCardApiTicketResult;
                     wxCardApiTicketBag.WxCardApiTicketExpireTime = SystemTime.Now.AddSeconds(wxCardApiTicketBag.WxCardApiTicketResult.expires_in);


### PR DESCRIPTION
GetWxCardApiTicketAsync方法中ticket过期，重新获取时type值错误。默认为“jsapi”，卡券使用wx_card