### PR TITLE
 商户的企业付款查询结果实体（GetTransferInfoResult）payment_time字段空值修复

### DIFF
--- a/src/Senparc.Weixin.TenPay/Senparc.Weixin.TenPay/V3/Universal/Entities/Result/TenPayV3Results.cs
+++ b/src/Senparc.Weixin.TenPay/Senparc.Weixin.TenPay/V3/Universal/Entities/Result/TenPayV3Results.cs
@@ -1143,6 +1143,7 @@ namespace Senparc.Weixin.TenPay.V3
                     payment_amount = int.Parse(GetXmlValue("payment_amount"));
                     transfer_time = GetXmlValue("transfer_time") ?? "";
                     desc = GetXmlValue("desc") ?? "";
+                    payment_time = GetXmlValue("payment_time") ?? "";
                 }
             }
         }


### PR DESCRIPTION
相关 Issue #1902 
新增的payment_time字段没有被赋值，使用payment_time的时候是Null