### PR TITLE
appId调用方式，重试时依旧使用appId方式，目前同步方法会把appId调用方式默默改成accessToken方式

### DIFF
--- a/src/Senparc.Weixin/Senparc.Weixin/CommonAPIs/ApiHandlerWapper/ApiHandlerWapperBase.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/CommonAPIs/ApiHandlerWapper/ApiHandlerWapperBase.cs
@@ -206,7 +206,7 @@ namespace Senparc.Weixin.CommonAPIs.ApiHandlerWapper
                                 accessTokenContainer_CheckRegisteredFunc,
                                 accessTokenContainer_GetAccessTokenResultFunc,
                                 invalidCredentialValue,
-                                fun, accessToken, false);
+                                fun, appId, false);
                 }
                 else
                 {


### PR DESCRIPTION
发现：生成公众号关注二维码，当前公众号未加入白名单时，会生成注册公众号列表中第一个公众号的二维码
原因：同步方法中，公众号未加入白名单将导致获取accessToken未null，符合重新验证条件，重新验证时因传入的accessTokenOrAppId参数未null，接口又默认获取注册列表第一个公众号了。
解决：查看异步方法的处理方式能解决这个问题，当未加入白名单时会抛出异常。改为异步方式即可，即：传入appId方式的调用重试时依旧使用appId方式