### PR TITLE
小程序实现订阅消息的管理

### DIFF
--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/NewTmpl/NewTmplApi.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/NewTmpl/NewTmplApi.cs
@@ -1,0 +1,262 @@
+﻿#region Apache License Version 2.0
+/*----------------------------------------------------------------
+
+Copyright 2020 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
+
+----------------------------------------------------------------*/
+#endregion Apache License Version 2.0
+
+/*----------------------------------------------------------------
+    Copyright (C) 2020 Senparc
+    
+    文件名：TemplateApi.cs
+    文件功能描述：小程序模板消息
+    
+    创建标识：Senparc - 20171215
+    
+    修改标识：Senparc - 20180107
+    修改描述：v2.8.5 将接口迁移至 WxOpen 中
+
+----------------------------------------------------------------*/
+
+using Senparc.NeuChar;
+using Senparc.Weixin.CommonAPIs;
+using Senparc.Weixin.Entities;
+using Senparc.Weixin.Open.WxaAPIs.NewTmpl.NewTmplJson;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Senparc.Weixin.Open.WxaAPIs.NewTmpl
+{
+    /// <summary>
+    /// 小程序模板消息接口
+    /// </summary>
+    public static class NewTmplApi
+    {
+        #region 同步方法
+
+
+        #region 模板快速设置
+        /// <summary>
+        /// 获取小程序模板库标题列表
+        /// subscribeMessage.getPubTemplateTitleList
+        /// </summary>
+        /// <param name="accessToken">接口调用凭证</param>
+        /// <param name="ids">类目 id，多个用逗号隔开</param>
+        /// <param name="start">用于分页，表示从 start 开始。从 0 开始计数。</param>
+        /// <param name="limit">用于分页，表示拉取 limit 条记录。最大为 30。</param>
+        /// <param name="timeOut">请求超时时间</param>
+        /// <returns></returns>
+        [ApiBind(NeuChar.PlatformType.WeChat_Open, "NewTmplApi.GetPubTemplateTitles", true)]
+        public static GetPubTemplateTitlesJsonResult GetPubTemplateTitles(string accessToken, string ids, int start, int limit, int timeOut = Config.TIME_OUT)
+        {
+            string urlFormat = Config.ApiMpHost + "/wxaapi/newtmpl/getpubtemplatetitles?access_token={0}";
+            urlFormat = $"{urlFormat}&ids={ids}&start={start}&limit={limit}";
+            return CommonJsonSend.Send<GetPubTemplateTitlesJsonResult>(accessToken, urlFormat, null, CommonJsonSendType.GET, timeOut: timeOut);
+        }
+
+        /// <summary>
+        /// 获取模板库某个模板标题下关键词库
+        /// subscribeMessage.getPubTemplateKeyWordsById
+        /// </summary>
+        /// <param name="accessToken">接口调用凭证</param>
+        /// <param name="tid">模板标题 id，可通过接口获取</param>
+        /// <param name="timeOut">请求超时时间</param>
+        /// <returns></returns>
+        [ApiBind(NeuChar.PlatformType.WeChat_Open, "NewTmplApi.GetPubTemplateKeyWordsById", true)]
+        public static GetPubTemplateKeyWordsByIdJsonResult GetPubTemplateKeyWordsById(string accessToken, string tid, int timeOut = Config.TIME_OUT)
+        {
+            string urlFormat = Config.ApiMpHost + "/wxaapi/newtmpl/getpubtemplatekeywords?access_token={0}";
+            urlFormat = $"{urlFormat}&tid={tid}";
+            return CommonJsonSend.Send<GetPubTemplateKeyWordsByIdJsonResult>(accessToken, urlFormat, null, CommonJsonSendType.GET, timeOut: timeOut);
+        }
+
+
+        /// <summary>
+        /// 组合模板并添加至帐号下的个人模板库
+        /// subscribeMessage.addTemplate
+        /// </summary>
+        /// <param name="accessToken">接口调用凭证</param>
+        /// <param name="id">模板标题id，可通过接口获取，也可登录小程序后台查看获取</param>
+        /// <param name="keywordIdList">开发者自行组合好的模板关键词列表，关键词顺序可以自由搭配（例如[3,5,4]或[4,5,3]），最多支持10个关键词组合</param>
+        /// <param name="timeOut">请求超时时间</param>
+        /// <returns></returns>
+        [ApiBind(NeuChar.PlatformType.WeChat_Open, "NewTmplApi.AddTemplate", true)]
+        public static AddTemplateJsonResult AddTemplate(string accessToken, string tid, int[] kidList, string sceneDesc = "", int timeOut = Config.TIME_OUT)
+        {
+            string urlFormat = Config.ApiMpHost + "/wxaapi/newtmpl/addtemplate?access_token={0}";
+            var data = new Dictionary<string, string>()
+            {
+                { "tid", tid },
+                { "sceneDesc", sceneDesc },
+            };
+            for (int i = 0; i < kidList.Length; i++)
+            {
+                data.Add($"kidList[{i}]", $"{kidList[i]}");
+            }
+            return CommonJsonSend.Send<AddTemplateJsonResult>(accessToken, urlFormat, data, timeOut: timeOut);
+        }
+
+        #endregion
+
+
+        #region 对已存在模板进行操作
+
+        /// <summary>
+        /// 获取帐号下已存在的模板列表
+        /// subscribeMessage.getTemplateList
+        /// </summary>
+        /// <param name="accessToken">接口调用凭证</param>
+        /// <param name="timeOut">请求超时时间</param>
+        /// <returns></returns>
+        [ApiBind(NeuChar.PlatformType.WeChat_Open, "NewTmplApi.GetTemplateList", true)]
+        public static GetTemplateListJsonResult GetTemplateList(string accessToken, int timeOut = Config.TIME_OUT)
+        {
+            string urlFormat = Config.ApiMpHost + "/wxaapi/newtmpl/gettemplate?access_token={0}";
+            return CommonJsonSend.Send<GetTemplateListJsonResult>(accessToken, urlFormat, null, CommonJsonSendType.GET, timeOut: timeOut);
+        }
+
+        /// <summary>
+        /// 删除帐号下的某个模板
+        /// </summary>
+        /// <param name="accessToken">接口调用凭证</param>
+        /// <param name="priTmplId">要删除的模板id</param>
+        /// <param name="timeOut">请求超时时间</param>
+        /// <returns></returns>
+        [ApiBind(NeuChar.PlatformType.WeChat_Open, "NewTmplApi.DelTemplate", true)]
+        public static WxJsonResult DelTemplate(string accessToken, string priTmplId, int timeOut = Config.TIME_OUT)
+        {
+            string urlFormat = Config.ApiMpHost + "/wxaapi/newtmpl/deltemplate?access_token={0}";
+            var data = new Dictionary<string, string>()
+            {
+                { "priTmplId", priTmplId }
+            };
+            return CommonJsonSend.Send<WxJsonResult>(accessToken, urlFormat, data, timeOut: timeOut);
+        }
+
+
+        #endregion
+
+        #endregion
+
+
+        #region 异步方法
+
+
+        #region 模板快速设置
+        /// <summary>
+        /// 【异步方法】获取小程序模板库标题列表
+        /// subscribeMessage.getPubTemplateTitleList
+        /// </summary>
+        /// <param name="accessToken">接口调用凭证</param>
+        /// <param name="ids">类目 id，多个用逗号隔开</param>
+        /// <param name="start">用于分页，表示从 start 开始。从 0 开始计数。</param>
+        /// <param name="limit">用于分页，表示拉取 limit 条记录。最大为 30。</param>
+        /// <param name="timeOut">请求超时时间</param>
+        /// <returns></returns>
+        [ApiBind(NeuChar.PlatformType.WeChat_Open, "NewTmplApi.GetPubTemplateTitles", true)]
+        public static async Task<GetPubTemplateTitlesJsonResult> GetPubTemplateTitlesAsync(string accessToken, string ids, int start, int limit, int timeOut = Config.TIME_OUT)
+        {
+            string urlFormat = Config.ApiMpHost + "/wxaapi/newtmpl/getpubtemplatetitles?access_token={0}";
+            urlFormat = $"{urlFormat}&ids={ids}&start={start}&limit={limit}";
+            return await CommonJsonSend.SendAsync<GetPubTemplateTitlesJsonResult>(accessToken, urlFormat, null, CommonJsonSendType.GET, timeOut: timeOut);
+        }
+
+        /// <summary>
+        /// 【异步方法】获取模板库某个模板标题下关键词库
+        /// subscribeMessage.getPubTemplateKeyWordsById
+        /// </summary>
+        /// <param name="accessToken">接口调用凭证</param>
+        /// <param name="tid">模板标题 id，可通过接口获取</param>
+        /// <param name="timeOut">请求超时时间</param>
+        /// <returns></returns>
+        [ApiBind(NeuChar.PlatformType.WeChat_Open, "NewTmplApi.GetPubTemplateKeyWordsById", true)]
+        public static async Task<GetPubTemplateKeyWordsByIdJsonResult> GetPubTemplateKeyWordsByIdAsync(string accessToken, string tid, int timeOut = Config.TIME_OUT)
+        {
+            string urlFormat = Config.ApiMpHost + "/wxaapi/newtmpl/getpubtemplatekeywords?access_token={0}";
+            urlFormat = $"{urlFormat}&tid={tid}";
+            return await CommonJsonSend.SendAsync<GetPubTemplateKeyWordsByIdJsonResult>(accessToken, urlFormat, null, CommonJsonSendType.GET, timeOut: timeOut);
+        }
+
+
+        /// <summary>
+        /// 【异步方法】组合模板并添加至帐号下的个人模板库
+        /// subscribeMessage.addTemplate
+        /// </summary>
+        /// <param name="accessToken">接口调用凭证</param>
+        /// <param name="id">模板标题id，可通过接口获取，也可登录小程序后台查看获取</param>
+        /// <param name="keywordIdList">开发者自行组合好的模板关键词列表，关键词顺序可以自由搭配（例如[3,5,4]或[4,5,3]），最多支持10个关键词组合</param>
+        /// <param name="timeOut">请求超时时间</param>
+        /// <returns></returns>
+        [ApiBind(NeuChar.PlatformType.WeChat_Open, "NewTmplApi.AddTemplate", true)]
+        public static async Task<AddTemplateJsonResult> AddTemplateAsync(string accessToken, string tid, int[] kidList, string sceneDesc = "", int timeOut = Config.TIME_OUT)
+        {
+            string urlFormat = Config.ApiMpHost + "/wxaapi/newtmpl/addtemplate?access_token={0}";
+            var data = new Dictionary<string, string>()
+            {
+                { "tid", tid },
+                { "sceneDesc", sceneDesc },
+            };
+            for (int i = 0; i < kidList.Length; i++)
+            {
+                data.Add($"kidList[{i}]", $"{kidList[i]}");
+            }
+            return await CommonJsonSend.SendAsync<AddTemplateJsonResult>(accessToken, urlFormat, data, timeOut: timeOut);
+        }
+
+        #endregion
+
+
+        #region 对已存在模板进行操作
+
+        /// <summary>
+        /// 【异步方法】获取帐号下已存在的模板列表
+        /// subscribeMessage.getTemplateList
+        /// </summary>
+        /// <param name="accessToken">接口调用凭证</param>
+        /// <param name="timeOut">请求超时时间</param>
+        /// <returns></returns>
+        [ApiBind(NeuChar.PlatformType.WeChat_Open, "NewTmplApi.GetTemplateList", true)]
+        public static async Task<GetTemplateListJsonResult> GetTemplateListAsync(string accessToken, int timeOut = Config.TIME_OUT)
+        {
+            string urlFormat = Config.ApiMpHost + "/wxaapi/newtmpl/gettemplate?access_token={0}";
+            return await CommonJsonSend.SendAsync<GetTemplateListJsonResult>(accessToken, urlFormat, null, CommonJsonSendType.GET, timeOut: timeOut);
+        }
+
+        /// <summary>
+        /// 【异步方法】删除帐号下的某个模板
+        /// </summary>
+        /// <param name="accessToken">接口调用凭证</param>
+        /// <param name="priTmplId">要删除的模板id</param>
+        /// <param name="timeOut">请求超时时间</param>
+        /// <returns></returns>
+        [ApiBind(NeuChar.PlatformType.WeChat_Open, "NewTmplApi.DelTemplate", true)]
+        public static async Task<WxJsonResult> DelTemplateAsync(string accessToken, string priTmplId, int timeOut = Config.TIME_OUT)
+        {
+            string urlFormat = Config.ApiMpHost + "/wxaapi/newtmpl/deltemplate?access_token={0}";
+            var data = new Dictionary<string, string>()
+            {
+                { "priTmplId", priTmplId }
+            };
+            return await CommonJsonSend.SendAsync<WxJsonResult>(accessToken, urlFormat, data, timeOut: timeOut);
+        }
+
+
+        #endregion
+
+
+        #endregion
+    }
+}

--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/NewTmpl/NewTmplJson/AddTemplateJsonResult.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/NewTmpl/NewTmplJson/AddTemplateJsonResult.cs
@@ -1,0 +1,51 @@
+﻿#region Apache License Version 2.0
+/*----------------------------------------------------------------
+
+Copyright 2017 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
+
+----------------------------------------------------------------*/
+#endregion Apache License Version 2.0
+
+/*----------------------------------------------------------------
+    Copyright (C) 2017 Senparc
+    
+    文件名：AddJsonResult.cs
+    文件功能描述：“获取模板库某个模板标题下关键词库”接口：Add 结果
+    
+    
+    创建标识：Senparc - 20170827
+
+----------------------------------------------------------------*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Senparc.Weixin.Entities;
+
+namespace Senparc.Weixin.Open.WxaAPIs.NewTmpl.NewTmplJson
+{
+    /// <summary>
+    /// “组合模板并添加至帐号下的个人模板库”接口：AddTemplate 结果
+    /// </summary>
+    public class AddTemplateJsonResult : WxJsonResult
+    {
+        /// <summary>
+        /// 添加至帐号下的模板id，发送小程序模板消息时所需
+        /// </summary>
+        public string priTmplId { get; set; }
+    }
+}

--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/NewTmpl/NewTmplJson/GetPubTemplateKeyWordsByIdJsonResult.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/NewTmpl/NewTmplJson/GetPubTemplateKeyWordsByIdJsonResult.cs
@@ -1,0 +1,69 @@
+﻿#region Apache License Version 2.0
+/*----------------------------------------------------------------
+
+Copyright 2017 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
+
+----------------------------------------------------------------*/
+#endregion Apache License Version 2.0
+
+/*----------------------------------------------------------------
+    Copyright (C) 2017 Senparc
+    
+    文件名：LibraryListJsonResult.cs
+    文件功能描述：“获取模板库某个模板标题下关键词库”接口：LibraryGet 结果
+    
+    
+    创建标识：Senparc - 20170827
+
+----------------------------------------------------------------*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Senparc.Weixin.Entities;
+
+namespace Senparc.Weixin.Open.WxaAPIs.NewTmpl.NewTmplJson
+{
+    /// <summary>
+    /// “获取模板库某个模板标题下关键词库”接口：GetPubTemplateKeyWordsById 结果
+    /// </summary>
+    public class GetPubTemplateKeyWordsByIdJsonResult : WxJsonResult
+    {
+        public string count { get; set; }
+        public List<GetPubTemplateKeyWordsByIdJsonResult_Data> data { get; set; }
+    }
+
+    public class GetPubTemplateKeyWordsByIdJsonResult_Data
+    {
+        /// <summary>
+        /// 关键词id，添加模板时需要
+        /// </summary>
+        public int kid { get; set; }
+        /// <summary>
+        /// 关键词内容
+        /// </summary>
+        public string name { get; set; }
+        /// <summary>
+        /// 关键词内容对应的示例
+        /// </summary>
+        public string example { get; set; }
+        /// <summary>
+        /// 参数类型
+        /// </summary>
+        public string rule { get; set; }
+    }
+}

--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/NewTmpl/NewTmplJson/GetPubTemplateTitlesJsonResult.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/NewTmpl/NewTmplJson/GetPubTemplateTitlesJsonResult.cs
@@ -1,0 +1,72 @@
+﻿#region Apache License Version 2.0
+/*----------------------------------------------------------------
+
+Copyright 2017 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
+
+----------------------------------------------------------------*/
+#endregion Apache License Version 2.0
+
+/*----------------------------------------------------------------
+    Copyright (C) 2017 Senparc
+    
+    文件名：LibraryListJsonResult.cs
+    文件功能描述：“获取小程序模板库标题列表”接口：LibraryList 结果
+    
+    
+    创建标识：Senparc - 20170827
+
+----------------------------------------------------------------*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Senparc.Weixin.Entities;
+
+namespace Senparc.Weixin.Open.WxaAPIs.NewTmpl.NewTmplJson
+{
+    /// <summary>
+    /// “获取小程序模板库标题列表”接口：GetPubTemplateTitles 结果
+    /// </summary>
+    public class GetPubTemplateTitlesJsonResult : WxJsonResult
+    {
+        public List<GetPubTemplateTitlesJsonResult_Data> data { get; set; }
+        /// <summary>
+        /// 模板库标题总数
+        /// </summary>
+        public int count { get; set; }
+    }
+
+    public class GetPubTemplateTitlesJsonResult_Data
+    {
+        /// <summary>
+        /// 模板标题id（获取模板标题下的关键词库时需要）
+        /// </summary>
+        public string tid { get; set; }
+        /// <summary>
+        /// 模板标题内容
+        /// </summary>
+        public string title { get; set; }
+        /// <summary>
+        /// 模版类型，2 为一次性订阅，3 为长期订阅
+        /// </summary>
+        public int type { get; set; }
+        /// <summary>
+        /// 模版所属类目 id
+        /// </summary>
+        public string categoryId { get; set; }
+    }
+}

--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/NewTmpl/NewTmplJson/GetTemplateListJsonResult.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/NewTmpl/NewTmplJson/GetTemplateListJsonResult.cs
@@ -1,0 +1,75 @@
+﻿#region Apache License Version 2.0
+/*----------------------------------------------------------------
+
+Copyright 2017 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
+
+----------------------------------------------------------------*/
+#endregion Apache License Version 2.0
+
+/*----------------------------------------------------------------
+    Copyright (C) 2017 Senparc
+    
+    文件名：ListJsonResult.cs
+    文件功能描述：“获取帐号下已存在的模板列表”接口：List 结果
+    
+    
+    创建标识：Senparc - 20170827
+
+----------------------------------------------------------------*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Senparc.Weixin.Entities;
+
+namespace Senparc.Weixin.Open.WxaAPIs.NewTmpl.NewTmplJson
+{
+    /// <summary>
+    /// “获取帐号下已存在的模板列表”接口：GetTemplateList 结果
+    /// </summary>
+    public class GetTemplateListJsonResult : WxJsonResult
+    {
+        /// <summary>
+        /// 帐号下的模板列表
+        /// </summary>
+        public List<GetTemplateListJsonResult_data> data { get; set; }
+    }
+
+    public class GetTemplateListJsonResult_data
+    {
+        /// <summary>
+        /// 模板id，发送小程序模板消息时所需
+        /// </summary>
+        public string priTmplId { get; set; }
+        /// <summary>
+        /// 模板标题
+        /// </summary>
+        public string title { get; set; }
+        /// <summary>
+        /// 模板内容
+        /// </summary>
+        public string content { get; set; }
+        /// <summary>
+        /// 模板内容示例
+        /// </summary>
+        public string example { get; set; }
+        /// <summary>
+        /// 模版类型，2 为一次性订阅，3 为长期订阅
+        /// </summary>
+        public int type { get; set; }
+    }
+}

--- a/src/Senparc.Weixin/Senparc.Weixin/CommonAPIs/CommonJsonSend.cs
+++ b/src/Senparc.Weixin/Senparc.Weixin/CommonAPIs/CommonJsonSend.cs
@@ -48,6 +48,8 @@ using Senparc.CO2NET.Helpers.Serializers;
 using Senparc.Weixin.Entities;
 using Senparc.Weixin.Exceptions;
 using Senparc.CO2NET.HttpUtility;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Senparc.Weixin.CommonAPIs
 {
@@ -91,26 +93,26 @@ namespace Senparc.Weixin.CommonAPIs
         /// </summary>
         static Action<string, string> postFailAction = (apiUrl, returnText) =>
         {
-             if (returnText.Contains("errcode"))
-             {
-                 //可能发生错误
-                 WxJsonResult errorResult = SerializerHelper.GetObject<WxJsonResult>(returnText);
-                 ErrorJsonResultException ex = null;
-                 if (errorResult.errcode != ReturnCode.请求成功)
-                 {
-                     //发生错误，记录异常
-                     throw new ErrorJsonResultException(
-                          string.Format("微信 POST 请求发生错误！错误代码：{0}，说明：{1}",
-                                        (int)errorResult.errcode,
-                                        errorResult.errmsg),
-                          null, errorResult, apiUrl);
-                 }
+            if (returnText.Contains("errcode"))
+            {
+                //可能发生错误
+                WxJsonResult errorResult = SerializerHelper.GetObject<WxJsonResult>(returnText);
+                ErrorJsonResultException ex = null;
+                if (errorResult.errcode != ReturnCode.请求成功)
+                {
+                    //发生错误，记录异常
+                    throw new ErrorJsonResultException(
+                         string.Format("微信 POST 请求发生错误！错误代码：{0}，说明：{1}",
+                                       (int)errorResult.errcode,
+                                       errorResult.errmsg),
+                         null, errorResult, apiUrl);
+                }
 
-                 if (Config.ThrownWhenJsonResultFaild && ex != null)
-                 {
-                     throw ex;//抛出异常
-                 }
-             }
+                if (Config.ThrownWhenJsonResultFaild && ex != null)
+                {
+                    throw ex;//抛出异常
+                }
+            }
         };
 
         #endregion
@@ -230,6 +232,11 @@ namespace Senparc.Weixin.CommonAPIs
                     case CommonJsonSendType.GET:
                         return await Get.GetJsonAsync<T>(CommonDI.CommonSP, url, afterReturnText: getFailAction).ConfigureAwait(false);
                     case CommonJsonSendType.POST:
+                        if (data is Dictionary<string, string> dictionary)
+                            return await Post.PostGetJsonAsync<T>(CommonDI.CommonSP, url, null, dictionary,
+                                timeOut: timeOut,
+                                afterReturnText: postFailAction).ConfigureAwait(false);
+
                         var jsonString = SerializerHelper.GetJsonString(data, jsonSetting);
                         using (MemoryStream ms = new MemoryStream())
                         {


### PR DESCRIPTION
1. 小程序实现订阅消息管理
接口文档：https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/subscribe-message/subscribeMessage.addTemplate.html
![image](https://user-images.githubusercontent.com/13127383/88824004-55cfd580-d1f8-11ea-9e8d-9ad8b0af67a6.png)


2. 小程序订阅消息接口几个POST请求的接口不支持Stream流传递，特使用Dictionary<string, string>
![image](https://user-images.githubusercontent.com/13127383/88824036-64b68800-d1f8-11ea-8107-91f6a8f77259.png)

该方式只是基于当前的框架实现，建议底层POST请求开放Content-Type出来，以及支持HttpContent的传递，这样让使用者更加的灵活