### PR TITLE
Fix "templete“ to ”template“

### DIFF
--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/TemplateMessage/TemplateApi.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/TemplateMessage/TemplateApi.cs
@@ -102,14 +102,14 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         /// <param name="timeOut">代理请求超时时间（毫秒）</param>
         /// <returns></returns>
         [ApiBind(NeuChar.PlatformType.WeChat_OfficialAccount, "TemplateApi.SendTemplateMessage", true)]
-        public static SendTemplateMessageResult SendTemplateMessage(string accessTokenOrAppId, string openId, string templateId, string url, object data, TempleteModel_MiniProgram miniProgram = null, int timeOut = Config.TIME_OUT)
+        public static SendTemplateMessageResult SendTemplateMessage(string accessTokenOrAppId, string openId, string templateId, string url, object data, TemplateModel_MiniProgram miniProgram = null, int timeOut = Config.TIME_OUT)
         {
             //文档：https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1500374289_66bvB
 
             return ApiHandlerWapper.TryCommonApi(accessToken =>
             {
                 string urlFormat = Config.ApiMpHost + "/cgi-bin/message/template/send?access_token={0}";
-                var msgData = new TempleteModel()
+                var msgData = new TemplateModel()
                 {
                     touser = openId,
                     template_id = templateId,
@@ -133,7 +133,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         /// <param name="timeOut">代理请求超时时间（毫秒）</param>
         /// <returns></returns>
         [ApiBind(NeuChar.PlatformType.WeChat_OfficialAccount, "TemplateApi.SendTemplateMessage", true)]
-        public static SendTemplateMessageResult SendTemplateMessage(string accessTokenOrAppId, string openId, ITemplateMessageBase templateMessageData, TempleteModel_MiniProgram miniProgram = null, int timeOut = Config.TIME_OUT)
+        public static SendTemplateMessageResult SendTemplateMessage(string accessTokenOrAppId, string openId, ITemplateMessageBase templateMessageData, TemplateModel_MiniProgram miniProgram = null, int timeOut = Config.TIME_OUT)
         {
             return SendTemplateMessage(accessTokenOrAppId, openId, templateMessageData.TemplateId,
                 templateMessageData.Url, templateMessageData, miniProgram, timeOut);
@@ -260,7 +260,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
             {
                 string urlFormat = Config.ApiMpHost + "/cgi-bin/message/template/subscribe?access_token={0}";
 
-                var msgData = new SubscribeMsgTempleteModel()
+                var msgData = new SubscribeMsgTemplateModel()
                 {
                     touser = toUserOpenId,
                     template_id = templateId,
@@ -291,12 +291,12 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         /// <param name="timeOut">代理请求超时时间（毫秒）</param>
         /// <returns></returns>        /// <returns></returns>
         [ApiBind(NeuChar.PlatformType.WeChat_OfficialAccount, "TemplateApi.SendTemplateMessageAsync", true)]
-        public static async Task<SendTemplateMessageResult> SendTemplateMessageAsync(string accessTokenOrAppId, string openId, string templateId, string url, object data, TempleteModel_MiniProgram miniProgram = null, int timeOut = Config.TIME_OUT)
+        public static async Task<SendTemplateMessageResult> SendTemplateMessageAsync(string accessTokenOrAppId, string openId, string templateId, string url, object data, TemplateModel_MiniProgram miniProgram = null, int timeOut = Config.TIME_OUT)
         {
             return await ApiHandlerWapper.TryCommonApiAsync(async accessToken =>
             {
                 string urlFormat = Config.ApiMpHost + "/cgi-bin/message/template/send?access_token={0}";
-                var msgData = new TempleteModel()
+                var msgData = new TemplateModel()
                 {
                     touser = openId,
                     template_id = templateId,
@@ -321,7 +321,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
         /// <param name="timeOut">代理请求超时时间（毫秒）</param>
         /// <returns></returns>
         [ApiBind(NeuChar.PlatformType.WeChat_OfficialAccount, "TemplateApi.SendTemplateMessageAsync", true)]
-        public static async Task<SendTemplateMessageResult> SendTemplateMessageAsync(string accessTokenOrAppId, string openId, ITemplateMessageBase templateMessageData, TempleteModel_MiniProgram miniProgram = null, int timeOut = Config.TIME_OUT)
+        public static async Task<SendTemplateMessageResult> SendTemplateMessageAsync(string accessTokenOrAppId, string openId, ITemplateMessageBase templateMessageData, TemplateModel_MiniProgram miniProgram = null, int timeOut = Config.TIME_OUT)
         {
             return await SendTemplateMessageAsync(accessTokenOrAppId, openId, templateMessageData.TemplateId,
                 templateMessageData.Url, templateMessageData, miniProgram, timeOut).ConfigureAwait(false);
@@ -450,7 +450,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs
             {
                 string urlFormat = Config.ApiMpHost + "/cgi-bin/message/template/subscribe?access_token={0}";
 
-                var msgData = new SubscribeMsgTempleteModel()
+                var msgData = new SubscribeMsgTemplateModel()
                 {
                     touser = toUserOpenId,
                     template_id = templateId,

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/TemplateMessage/TemplateMessageJson/TempleteModel/SubscribeMsgTempleteModel.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/TemplateMessage/TemplateMessageJson/TempleteModel/SubscribeMsgTempleteModel.cs
@@ -21,7 +21,7 @@ Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
 /*----------------------------------------------------------------
     Copyright (C) 2020 Senparc
     
-    文件名：SubscribeMsgTempleteModel.cs
+    文件名：SubscribeMsgTemplateModel.cs
     文件功能描述：模板消息接口需要的数据
     
     
@@ -34,7 +34,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs.TemplateMessage
     /// <summary>
     /// 一次性订阅消息模板
     /// </summary>
-    public class SubscribeMsgTempleteModel: TempleteModel
+    public class SubscribeMsgTemplateModel: TemplateModel
     {
         /// <summary>
         /// 消息标题，15字以内
@@ -46,7 +46,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs.TemplateMessage
         /// </summary>
         public string scene { get; set; }
 
-        public SubscribeMsgTempleteModel() : base()
+        public SubscribeMsgTemplateModel() : base()
         {
         }
     }

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/TemplateMessage/TemplateMessageJson/TempleteModel/TempleteModel.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/AdvancedAPIs/TemplateMessage/TemplateMessageJson/TempleteModel/TempleteModel.cs
@@ -21,7 +21,7 @@ Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
 /*----------------------------------------------------------------
     Copyright (C) 2020 Senparc
     
-    文件名：TempleteModel.cs
+    文件名：TemplateModel.cs
     文件功能描述：模板消息接口需要的数据
     
     
@@ -40,7 +40,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs.TemplateMessage
     /// <summary>
     /// 普通模板消息参数
     /// </summary>
-    public class TempleteModel
+    public class TemplateModel
     {
         /// <summary>
         /// 目标用户OpenId
@@ -65,7 +65,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs.TemplateMessage
         /// <summary>
         /// 跳小程序所需数据，不需跳小程序可不用传该数据
         /// </summary>
-        public TempleteModel_MiniProgram miniprogram { get; set; }
+        public TemplateModel_MiniProgram miniprogram { get; set; }
 
         /// <summary>
         /// 数据
@@ -73,7 +73,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs.TemplateMessage
         public object data { get; set; }
 
 
-        public TempleteModel()
+        public TemplateModel()
         {
             topcolor = "#FF0000";
         }
@@ -83,7 +83,7 @@ namespace Senparc.Weixin.MP.AdvancedAPIs.TemplateMessage
     /// 小程序定义
     /// </summary>
     //[Senparc.Weixin.Helpers.JsonSetting.IgnoreValue(false)]
-    public class TempleteModel_MiniProgram
+    public class TemplateModel_MiniProgram
     {
         /// <summary>
         /// 小程序AppId

--- a/src/Senparc.Weixin.WxOpen/src/Senparc.Weixin.WxOpen/Senparc.Weixin.WxOpen/AdvancedAPIs/Template/TemplateApi.cs
+++ b/src/Senparc.Weixin.WxOpen/src/Senparc.Weixin.WxOpen/Senparc.Weixin.WxOpen/AdvancedAPIs/Template/TemplateApi.cs
@@ -83,7 +83,7 @@ namespace Senparc.Weixin.WxOpen.AdvancedAPIs.Template
             return WxOpenApiHandlerWapper.TryCommonApi(accessToken =>
             {
                 string urlFormat = Config.ApiMpHost + "/cgi-bin/message/wxopen/template/send?access_token={0}";
-                var msgData = new TempleteModel()
+                var msgData = new TemplateModel()
                 {
                     touser = openId,
                     template_id = templateId,
@@ -280,7 +280,7 @@ namespace Senparc.Weixin.WxOpen.AdvancedAPIs.Template
             return await WxOpenApiHandlerWapper.TryCommonApiAsync(async accessToken =>
             {
                 string urlFormat = Config.ApiMpHost + "/cgi-bin/message/wxopen/template/send?access_token={0}";
-                var msgData = new TempleteModel()
+                var msgData = new TemplateModel()
                 {
                     touser = openId,
                     template_id = templateId,

--- a/src/Senparc.Weixin.WxOpen/src/Senparc.Weixin.WxOpen/Senparc.Weixin.WxOpen/AdvancedAPIs/Template/TemplateJson/TempleteModel.cs
+++ b/src/Senparc.Weixin.WxOpen/src/Senparc.Weixin.WxOpen/Senparc.Weixin.WxOpen/AdvancedAPIs/Template/TemplateJson/TempleteModel.cs
@@ -21,7 +21,7 @@ Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
 /*----------------------------------------------------------------
     Copyright (C) 2020 Senparc
     
-    文件名：TempleteModel.cs
+    文件名：TemplateModel.cs
     文件功能描述：小程序模板消息接口需要的数据
     
     
@@ -44,7 +44,7 @@ namespace Senparc.Weixin.WxOpen.AdvancedAPIs.Template
     /// <summary>
     /// 模板消息Post数据
     /// </summary>
-    public class TempleteModel
+    public class TemplateModel
     {
         /// <summary>
         /// 目标用户OpenId
@@ -84,7 +84,7 @@ namespace Senparc.Weixin.WxOpen.AdvancedAPIs.Template
 
 
 
-        public TempleteModel()
+        public TemplateModel()
         {
         }
     }


### PR DESCRIPTION
修正模板消息的相关代码命名错误，应为”Templ**a**te“ ，而不是"Templ**e**te"