### PR TITLE
RequestMessageEventBase子类请求对象MsgID字段赋值时，同时赋值父类MsgId

### DIFF
--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Entities/Request/Event/RequestMessageEvent_MassSendJobFinish.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Entities/Request/Event/RequestMessageEvent_MassSendJobFinish.cs
@@ -36,6 +36,7 @@ Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
 ----------------------------------------------------------------*/
 
 using Senparc.NeuChar.Entities;
+
 using System;
 using System.Collections.Generic;
 
@@ -135,8 +136,18 @@ namespace Senparc.Weixin.MP.Entities
 
         /// <summary>
         /// 群发的消息ID
+        /// 2022-01-06 YZQ Modify
         /// </summary>
-        public long MsgID { get; set; }
+        public long MsgID
+        {
+            get { return this._MsgID; }
+            set
+            {
+                base.MsgId = value;
+                this._MsgID = value;
+            }
+        }
+        private long _MsgID;
 
         [Obsolete("请使用MsgID")]
         public new long MsgId { get; set; }

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Entities/Request/Event/RequestMessageEvent_TemplateSendJobFinish.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Entities/Request/Event/RequestMessageEvent_TemplateSendJobFinish.cs
@@ -54,8 +54,18 @@ namespace Senparc.Weixin.MP.Entities
 
         /// <summary>
         /// 消息id
+        /// 2022-01-06 YZQ Modify
         /// </summary>
-        public long MsgID { get; set; }
+        public long MsgID
+        {
+            get { return this._MsgID; }
+            set
+            {
+                base.MsgId = value;
+                this._MsgID = value;
+            }
+        }
+        private long _MsgID;
 
         [Obsolete("请使用MsgID")]
         public new long MsgId { get; set; }


### PR DESCRIPTION
因消息排重时使用接口IRequestMessageEventBase定义的MsgId进行排重键判定，当不指定具体实现类时MsgId值则为零，若使用通讯的PostModel签名作为排重依据，则在已处理的消息链表中表现较为混乱