### PR TITLE
avoid ui dead lock

### DIFF
--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Containers/AccessTokenContainer.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Containers/AccessTokenContainer.cs
@@ -261,7 +261,7 @@ namespace Senparc.Weixin.MP.Containers
             //为JsApiTicketContainer进行自动注册
             var registerJsApiTask = JsApiTicketContainer.RegisterAsync(appId, appSecret, name);
 
-            await Task.WhenAll(new[] { registerTask, registerJsApiTask });//等待所有任务完成
+            await Task.WhenAll(new[] { registerTask, registerJsApiTask }).ConfigureAwait(false);//等待所有任务完成
         }
 
         #region AccessToken


### PR DESCRIPTION
all other RegisterAsync has .ConfigureAwait(false), except AccessTokenContainer, cause when run in winform mode, it cause ui dead lock for 10 seconds.