### PR TITLE
订单页path信息 单独设置

### DIFF
--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/SecurityJson/ApplySetOrderPathInfo.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/SecurityJson/ApplySetOrderPathInfo.cs
@@ -1,0 +1,76 @@
+﻿#region Apache License Version 2.0
+/*----------------------------------------------------------------
+
+Copyright 2022 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
+
+----------------------------------------------------------------*/
+#endregion Apache License Version 2.0
+
+/*----------------------------------------------------------------
+    Copyright (C) 2023 Senparc
+    
+    文件名：ApplySetOrderPathInfo.cs
+    文件功能描述：申请设置订单页 path 信息
+    
+    
+    创建标识：mojinxun - 20230207
+
+----------------------------------------------------------------*/
+
+using System.Collections.Generic;
+
+namespace Senparc.Weixin.Open.WxaAPIs
+{
+    /// <summary>
+    /// 申请设置订单页 path 信息
+    /// </summary>
+    public class ApplySetOrderPathInfo
+    {
+        /// <summary>
+        /// 订单页path
+        /// </summary>
+        public string path { get; set; }
+
+        /// <summary>
+        /// 申请提交的图片url，审核版会显示
+        /// </summary>
+        public List<string> img_list { get; set; }
+
+        /// <summary>
+        /// 申请提交的视频url，审核版会显示
+        /// </summary>
+        public string video { get; set; }
+
+        /// <summary>
+        /// 申请提交的测试账号，审核版会显示
+        /// </summary>
+        public string test_account { get; set; }
+
+        /// <summary>
+        /// 申请提交的测试密码，审核版会显示
+        /// </summary>
+        public string test_pwd { get; set; }
+
+        /// <summary>
+        /// 申请提交的测试备注，审核版会显示
+        /// </summary>
+        public string test_remark { get; set; }
+
+        /// <summary>
+        /// 申请提交的批量的appid
+        /// </summary>
+        public List<string> appid_list { get; set; }
+    }
+}

--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/SecurityJson/ApplySetOrderPathInfoJsonResult.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/SecurityJson/ApplySetOrderPathInfoJsonResult.cs
@@ -1,0 +1,49 @@
+﻿#region Apache License Version 2.0
+/*----------------------------------------------------------------
+
+Copyright 2023 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
+
+----------------------------------------------------------------*/
+#endregion Apache License Version 2.0
+
+/*----------------------------------------------------------------
+    Copyright (C) 2020 Senparc
+
+    文件名：ApplySetOrderPathInfoJsonResult.cs
+    文件功能描述：申请设置订单页path信息结果
+
+
+    创建标识：mojinxun - 20230207
+
+----------------------------------------------------------------*/
+
+using Senparc.Weixin.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Senparc.Weixin.Open.WxaAPIs
+{
+    /// <summary>
+    /// 申请设置订单页path信息结果
+    /// </summary>
+    [Serializable]
+    public class ApplySetOrderPathInfoJsonResult : WxJsonResult
+    {
+        
+    }
+}

--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/SecurityJson/GetOrderPathInfoJsonResult.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/SecurityJson/GetOrderPathInfoJsonResult.cs
@@ -1,0 +1,97 @@
+﻿#region Apache License Version 2.0
+/*----------------------------------------------------------------
+
+Copyright 2023 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
+
+----------------------------------------------------------------*/
+#endregion Apache License Version 2.0
+
+/*----------------------------------------------------------------
+    Copyright (C) 2022 Senparc
+
+    文件名：GetOrderPathInfoJsonResult.cs
+    文件功能描述：获取订单页 path 信息结果
+
+
+    创建标识：mojinxun - 20230207
+
+----------------------------------------------------------------*/
+
+using Senparc.Weixin.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Senparc.Weixin.Open.WxaAPIs
+{
+    /// <summary>
+    /// 获取订单页 path 信息结果
+    /// </summary>
+    [Serializable]
+    public class GetOrderPathInfoJsonResult : WxJsonResult
+    {
+        /// <summary>
+        /// 订单页 path 信息
+        /// </summary>
+        public GetOrderPathInfoMsg msg { get; set; }
+    }
+
+    [Serializable]
+    public class GetOrderPathInfoMsg
+    {
+        /// <summary>
+        /// 订单页path
+        /// </summary>
+        public string path { get; set; }
+
+        /// <summary>
+        /// 申请提交的图片url，审核版会显示
+        /// </summary>
+        public List<string> img_list { get; set; }
+
+        /// <summary>
+        /// 申请提交的视频url，审核版会显示
+        /// </summary>
+        public string video { get; set; }
+
+        /// <summary>
+        /// 申请提交的测试账号，审核版会显示
+        /// </summary>
+        public string test_account { get; set; }
+
+        /// <summary>
+        /// 申请提交的测试密码，审核版会显示
+        /// </summary>
+        public string test_pwd { get; set; }
+
+        /// <summary>
+        /// 申请提交的测试备注，审核版会显示
+        /// </summary>
+        public string test_remark { get; set; }
+
+        /// <summary>
+        /// 订单页 path 状态，见其他说明
+        /// </summary>
+        public int status { get; set; }
+
+        /// <summary>
+        /// 申请时间
+        /// </summary>
+        public long apply_time { get; set; }
+    }
+
+}

--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/WxaApi.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/WxaAPIs/WxaApi.cs
@@ -200,6 +200,7 @@ namespace Senparc.Weixin.Open.WxaAPIs
         }
         #endregion
 
+        #region 查询小程序版本信息
         /// <summary>
         /// 查询小程序版本信息
         /// <para>调用本接口可以查询小程序的体验版和线上版本信息。</para>
@@ -218,6 +219,47 @@ namespace Senparc.Weixin.Open.WxaAPIs
             };
             return CommonJsonSend.Send<GetVersionInfoJsonResult>(null, url, data, CommonJsonSendType.POST);
         }
+        #endregion
+
+        #region 订单页path信息
+        /// <summary>
+        /// 获取订单页 path 信息
+        /// <para>该接口用于获取订单页 path 信息。</para>
+        /// https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/miniprogram-management/basic-info-management/getOrderPathInfo.html
+        /// </summary>
+        /// <param name="accessToken">第三方平台接口调用凭证authorizer_access_token，该参数为 URL 参数，非 Body 参数。</param>
+        /// <param name="info_type">0:线上版，1:审核版</param>
+        /// <returns></returns>
+        public static GetOrderPathInfoJsonResult GetOrderPathInfo(string accessToken, int info_type)
+        {
+            var url = $"{Config.ApiMpHost}/wxa/security/getorderpathinfo?access_token={accessToken.AsUrlData()}";
+
+            var data = new
+            {
+                info_type
+            };
+            return CommonJsonSend.Send<GetOrderPathInfoJsonResult>(null, url, data, CommonJsonSendType.POST);
+        }
+
+        /// <summary>
+        /// 申请设置订单页 path 信息
+        /// <para>该接口用于申请设置订单页 path 信息</para>
+        /// https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/miniprogram-management/basic-info-management/applySetOrderPathInfo.html
+        /// </summary>
+        /// <param name="accessToken">第三方平台接口调用凭证authorizer_access_token，该参数为 URL 参数，非 Body 参数。</param>
+        /// <param name="info_type">0:线上版，1:审核版</param>
+        /// <returns></returns>
+        public static ApplySetOrderPathInfoJsonResult ApplySetOrderPathInfo(string accessToken, ApplySetOrderPathInfo batch_req)
+        {
+            var url = $"{Config.ApiMpHost}/wxa/security/applysetorderpathinfo?access_token={accessToken.AsUrlData()}";
+
+            var data = new
+            {
+                batch_req
+            };
+            return CommonJsonSend.Send<ApplySetOrderPathInfoJsonResult>(null, url, data, CommonJsonSendType.POST);
+        }
+        #endregion
 
         #endregion
 
@@ -366,6 +408,7 @@ namespace Senparc.Weixin.Open.WxaAPIs
         }
         #endregion
 
+        #region 小程序版本信息
         /// <summary>
         /// 【异步方法】查询小程序版本信息
         /// <para>调用本接口可以查询小程序的体验版和线上版本信息。</para>
@@ -384,6 +427,49 @@ namespace Senparc.Weixin.Open.WxaAPIs
             };
             return await CommonJsonSend.SendAsync<GetVersionInfoJsonResult>(null, url, data, CommonJsonSendType.POST);
         }
+        #endregion
+
+        #region 订单页path信息
+        /// <summary>
+        /// 获取订单页 path 信息
+        /// <para>该接口用于获取订单页 path 信息。</para>
+        /// https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/miniprogram-management/basic-info-management/getOrderPathInfo.html
+        /// </summary>
+        /// <param name="accessToken">第三方平台接口调用凭证authorizer_access_token，该参数为 URL 参数，非 Body 参数。</param>
+        /// <param name="info_type">0:线上版，1:审核版</param>
+        /// <returns></returns>
+        public static async Task<GetOrderPathInfoJsonResult> GetOrderPathInfoAsync(string accessToken, int info_type)
+        {
+            var url = $"{Config.ApiMpHost}/wxa/security/getorderpathinfo?access_token={accessToken.AsUrlData()}";
+
+            var data = new
+            {
+                info_type
+            };
+            return await CommonJsonSend.SendAsync<GetOrderPathInfoJsonResult>(null, url, data, CommonJsonSendType.POST);
+        }
+
+        /// <summary>
+        /// 申请设置订单页 path 信息
+        /// <para>该接口用于申请设置订单页 path 信息</para>
+        /// https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/miniprogram-management/basic-info-management/applySetOrderPathInfo.html
+        /// </summary>
+        /// <param name="accessToken">第三方平台接口调用凭证authorizer_access_token，该参数为 URL 参数，非 Body 参数。</param>
+        /// <param name="info_type">0:线上版，1:审核版</param>
+        /// <returns></returns>
+        public static async Task<ApplySetOrderPathInfoJsonResult> ApplySetOrderPathInfoAsync(string accessToken, ApplySetOrderPathInfo batch_req)
+        {
+            var url = $"{Config.ApiMpHost}/wxa/security/applysetorderpathinfo?access_token={accessToken.AsUrlData()}";
+
+            var data = new
+            {
+                batch_req
+            };
+            return await CommonJsonSend.SendAsync<ApplySetOrderPathInfoJsonResult>(null, url, data, CommonJsonSendType.POST);
+        }
+        #endregion
+
+
 
         #endregion
 


### PR DESCRIPTION
订单页 path 信息 获取与设置
获取：
[获取](https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/miniprogram-management/basic-info-management/getOrderPathInfo.html)

[设置](https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/miniprogram-management/basic-info-management/applySetOrderPathInfo.html)