### PR TITLE
Update TradeBillQueryRequestData.cs

### DIFF
--- a/src/Senparc.Weixin.TenPay/Senparc.Weixin.TenPayV3/Apis/BasePay/Entities/RequestData/TradeBillQueryRequestData.cs
+++ b/src/Senparc.Weixin.TenPay/Senparc.Weixin.TenPayV3/Apis/BasePay/Entities/RequestData/TradeBillQueryRequestData.cs
@@ -45,7 +45,7 @@ namespace Senparc.Weixin.TenPayV3.Apis.BasePay
         /// <param name="bill_date">账单日期 格式yyyy-MM-DD 仅支持三个月内的账单下载申请。</param>
         /// <param name="bill_type">账单类型 不填则默认是ALL</param>
         /// <param name="tar_type">压缩类型  不填则默认是数据流</param>
-        public TradeBillQueryRequestData(string bill_date, string bill_type = "ALL", string tar_type = "")
+        public TradeBillQueryRequestData(string bill_date, string bill_type = "ALL", string tar_type = null)
         {
             this.bill_date = bill_date;
             this.bill_type = bill_type;


### PR DESCRIPTION
需要把此构造函数中的tar_type初始值设置成null，如果设置成“”，构造apiurl为：https://api.mch.weixin.qq.com/v3/bill/tradebill?bill_date=2023-05-06&bill_type=ALL&tar_type= 微信返回PARAM_ERROR参数错误，改成null后apiurl：https://api.mch.weixin.qq.com/v3/bill/tradebill?bill_date=2023-05-06&bill_type=ALL，就能正确获取账单