### PR TITLE
添加获取稳定版接口调用凭据GetStableAccessToken

### DIFF
--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/CommonAPIs/CommonApi.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/CommonAPIs/CommonApi.cs
@@ -110,6 +110,38 @@ namespace Senparc.Weixin.MP.CommonAPIs
             }
 
             return result;
+        }   
+        
+        /// <summary>
+        /// 获取稳定版接口调用凭据
+        /// </summary>
+        /// <param name="grant_type">获取access_token填写client_credential</param>
+        /// <param name="appid">账号唯一凭证，即 AppID，可在「微信公众平台 - 设置 - 开发设置」页中获得。（需要已经成为开发者，且帐号没有异常状态）</param>
+        /// <param name="secret">帐号唯一凭证密钥，即 AppSecret，获取方式同 appid</param>
+        /// <param name="force_refresh">默认使用 false。
+        /// 1. force_refresh = false 时为普通调用模式，access_token 有效期内重复调用该接口不会更新 access_token；
+        /// 2. 当force_refresh = true 时为强制刷新模式，会导致上次获取的 access_token 失效，并返回新的 access_token</param>
+        /// <returns></returns>
+        [NcApiBind(NeuChar.PlatformType.WeChat_OfficialAccount, "CommonApi.GetStableAccessToken", false, ApiRequestMethod = CO2NET.WebApi.ApiRequestMethod.Post)]
+        public static AccessTokenResult GetStableAccessToken(string appid, string secret, string grant_type = "client_credential",bool force_refresh=false)
+        {
+            var url = Config.ApiMpHost + "/cgi-bin/stable_token";
+            var data = new
+            {
+                grant_type= "client_credential",
+                appid= appid,
+                secret= secret,
+                force_refresh= false
+            };
+            AccessTokenResult result = CommonJsonSend.Send<AccessTokenResult>(null, url, data, CommonJsonSendType.POST);
+            if (Config.ThrownWhenJsonResultFaild && result.errcode != ReturnCode.请求成功)
+            {
+                throw new ErrorJsonResultException(
+                    string.Format("微信请求发生错误（CommonApi.GetStableAccessToken）！错误代码：{0}，说明：{1}",
+                        (int)result.errcode, result.errmsg), null, result);
+            }
+
+            return result;
         }
 
         //已经迁移到 UserApi 下
@@ -226,6 +258,38 @@ namespace Senparc.Weixin.MP.CommonAPIs
             {
                 throw new ErrorJsonResultException(
                     string.Format("微信请求发生错误（CommonApi.GetToken）！错误代码：{0}，说明：{1}",
+                        (int)result.errcode, result.errmsg), null, result);
+            }
+
+            return result;
+        }
+        
+        /// <summary>
+        /// 【异步方法】获取稳定版接口调用凭据
+        /// </summary>
+        /// <param name="grant_type">获取access_token填写client_credential</param>
+        /// <param name="appid">账号唯一凭证，即 AppID，可在「微信公众平台 - 设置 - 开发设置」页中获得。（需要已经成为开发者，且帐号没有异常状态）</param>
+        /// <param name="secret">帐号唯一凭证密钥，即 AppSecret，获取方式同 appid</param>
+        /// <param name="force_refresh">默认使用 false。
+        /// 1. force_refresh = false 时为普通调用模式，access_token 有效期内重复调用该接口不会更新 access_token；
+        /// 2. 当force_refresh = true 时为强制刷新模式，会导致上次获取的 access_token 失效，并返回新的 access_token</param>
+        /// <returns></returns>
+        [NcApiBind(NeuChar.PlatformType.WeChat_OfficialAccount, "CommonApi.GetStableAccessTokenAsync", false, ApiRequestMethod = CO2NET.WebApi.ApiRequestMethod.Post)]
+        public static async Task<AccessTokenResult> GetStableAccessTokenAsync(string appid, string secret, string grant_type = "client_credential",bool force_refresh=false)
+        {
+            var url = Config.ApiMpHost + "/cgi-bin/stable_token";
+            var data = new
+            {
+                grant_type= "client_credential",
+                appid= appid,
+                secret= secret,
+                force_refresh= false
+            };
+
+            AccessTokenResult result = await CommonJsonSend.SendAsync<AccessTokenResult>(null, url, data, CommonJsonSendType.POST);
+            if (Config.ThrownWhenJsonResultFaild && result.errcode != ReturnCode.请求成功)
+            {
+                throw new ErrorJsonResultException(string.Format("微信请求发生错误（CommonApi.GetStableAccessTokenAsync）！错误代码：{0}，说明：{1}",
                         (int)result.errcode, result.errmsg), null, result);
             }
 


### PR DESCRIPTION
# 获取稳定版接口调用凭据 官网接口
> https://developers.weixin.qq.com/doc/offiaccount/Basic_Information/getStableAccessToken.html

# 请求数据示例
POST https://api.weixin.qq.com/cgi-bin/stable_token
请求示例1（不传递force_refresh，默认值为false）:
```
{
    "grant_type": "client_credential",
    "appid": "APPID",
    "secret": "APPSECRET"
}
```
请求示例2（设置force_refresh为false）:
```
{
    "grant_type": "client_credential",
    "appid": "APPID",
    "secret": "APPSECRET",
    "force_refresh": false
} 
```