### PR TITLE
企业微信三方代开发处理事件: 修复Async方法循环调用的Bug

### DIFF
--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Entities/Request/ThirdPartyInfo/RequestMessageInfo_Reset_Permanent_Code.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Entities/Request/ThirdPartyInfo/RequestMessageInfo_Reset_Permanent_Code.cs
@@ -1,0 +1,23 @@
+/*----------------------------------------------------------------
+    Copyright (C) 2023 Senparc
+    
+    文件名：RequestMessageInfo_Reset_Permanent_Code.cs
+    文件功能描述：推广二维码注册企业微信完成通知
+    
+    
+    创建标识：dukecheng - 2023-09-11
+    
+----------------------------------------------------------------*/
+
+namespace Senparc.Weixin.Work.Entities
+{
+    /// <summary>
+    /// 代开发应用=>授权客户=>应用Secret 重新获取通知
+    /// </summary>
+    public class RequestMessageInfo_Reset_Permanent_Code : ThirdPartyInfoBase, IThirdPartyInfoBase
+    {
+        public override ThirdPartyInfo InfoType => ThirdPartyInfo.RESET_PERMANENT_CODE;
+
+        public string AuthCode { get; set; }
+    }
+}

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Entities/Request/ThirdPartyInfo/RequestMessager_Register_Corp.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Entities/Request/ThirdPartyInfo/RequestMessager_Register_Corp.cs
@@ -1,4 +1,4 @@
-﻿/*----------------------------------------------------------------
+/*----------------------------------------------------------------
     Copyright (C) 2023 Senparc
     
     文件名：RequestMessager_Register_Corp.cs
@@ -23,15 +23,12 @@ namespace Senparc.Weixin.Work.Entities
         //    get { return RequestMsgType.Unknown; }
         //}
 
-        public ThirdPartyInfo InfoType
-        {
-            get { return ThirdPartyInfo.REGISTER_CORP; }
-        }
+        public override ThirdPartyInfo InfoType => ThirdPartyInfo.REGISTER_CORP;
+
         /// <summary>
         /// 服务商corpid
         /// </summary>
         public string ServiceCorpId { get; set; }
-        public string TimeStamp { get; set; }
         /// <summary>
         /// 创建企业对应的注册码
         /// </summary>

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Enums.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Enums.cs
@@ -1,4 +1,4 @@
-﻿/*----------------------------------------------------------------
+/*----------------------------------------------------------------
     Copyright (C) 2023 Senparc
 
     文件名：Enums.cs
@@ -198,7 +198,7 @@ namespace Senparc.Weixin.Work
         OPEN_APPROVAL_CHANGE
         #endregion
     }
-    
+
     public enum TencentGender
     {
         /// <summary>
@@ -259,16 +259,20 @@ namespace Senparc.Weixin.Work
         /// <summary>
         /// 重置永久授权码通知
         /// </summary>
-        RESET_PERMANENT_CODE
+        RESET_PERMANENT_CODE,
+        /// <summary>
+        /// 开启订单
+        /// </summary>
+        OPEN_ORDER,
     }
-    
+
     public enum ExternalAttributeType
     {
         Text,
         Web,
         Miniprogram
     }
-    
+
     public enum GroupChatJoinScene
     {
         /// <summary>

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/MessageHandlers/Async/WorkMessageHandler.Async.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/MessageHandlers/Async/WorkMessageHandler.Async.cs
@@ -1,4 +1,4 @@
-﻿/*----------------------------------------------------------------
+/*----------------------------------------------------------------
     Copyright (C) 2023 Senparc
     
     文件名：WorkMessageHandler.cs
@@ -20,6 +20,7 @@ using Senparc.NeuChar;
 using System.Threading.Tasks;
 using System.Threading;
 using Senparc.Weixin.Work.Entities.Request.Event;
+using System;
 
 namespace Senparc.Weixin.Work.MessageHandlers
 {
@@ -29,7 +30,7 @@ namespace Senparc.Weixin.Work.MessageHandlers
     {
         public override async Task BuildResponseMessageAsync(CancellationToken cancellationToken)
         {
-          
+
             switch (RequestMessage.MsgType)
             {
                 case RequestMsgType.Unknown: //第三方回调
@@ -44,7 +45,7 @@ namespace Senparc.Weixin.Work.MessageHandlers
                         throw new WeixinException("没有找到合适的消息类型。");
                     }
                 }
-                    break;
+                break;
                 //以下是普通信息
                 case RequestMsgType.Text:
                 {
@@ -52,7 +53,7 @@ namespace Senparc.Weixin.Work.MessageHandlers
                     ResponseMessage = await OnTextOrEventRequestAsync(requestMessage) ??
                                       await OnTextRequestAsync(requestMessage);
                 }
-                    break;
+                break;
                 case RequestMsgType.Location:
                     ResponseMessage = await OnLocationRequestAsync(RequestMessage as RequestMessageLocation);
                     break;
@@ -77,7 +78,7 @@ namespace Senparc.Weixin.Work.MessageHandlers
                     ResponseMessage = await OnTextOrEventRequestAsync(requestMessageText) ??
                                       await OnEventRequestAsync(RequestMessage as IRequestMessageEventBase);
                 }
-                    break;
+                break;
                 default:
                     throw new UnknownRequestMsgTypeException("未知的MsgType请求类型", null);
             }
@@ -182,8 +183,7 @@ namespace Senparc.Weixin.Work.MessageHandlers
                     responseMessage = await OnEvent_ViewRequestAsync(RequestMessage as RequestMessageEvent_View);
                     break;
                 case Event.PIC_PHOTO_OR_ALBUM: //弹出拍照或者相册发图
-                    responseMessage =
-                        await OnEvent_PicPhotoOrAlbumRequestAsync(
+                    responseMessage = await OnEvent_PicPhotoOrAlbumRequestAsync(
                             RequestMessage as RequestMessageEvent_Pic_Photo_Or_Album);
                     break;
                 case Event.SCANCODE_PUSH: //扫码推事件
@@ -281,7 +281,7 @@ namespace Senparc.Weixin.Work.MessageHandlers
                                     RequestMessage as RequestMessageEvent_Change_ExternalContact_Add);
                             break;
                         case ExternalContactChangeType.edit_external_contact:
-                            OnEvent_ChangeExternalContactUpdateRequestAsync(
+                            responseMessage = await OnEvent_ChangeExternalContactUpdateRequestAsync(
                                 requestMessage as RequestMessageEvent_Change_ExternalContact_Modified);
                             break;
                         case ExternalContactChangeType.add_half_external_contact:
@@ -680,7 +680,7 @@ namespace Senparc.Weixin.Work.MessageHandlers
         /// <returns></returns>
         public virtual async Task<IWorkResponseMessageBase> OnEvent_SwitchWorkbenchModel(RequestMessageEvent_Switch_WorkBench_Mode requestMessage)
         {
-            return await Task.Run(()=>OnEvent_SwitchWorkBenchMode(requestMessage)).ConfigureAwait (false);
+            return await Task.Run(() => OnEvent_SwitchWorkBenchMode(requestMessage)).ConfigureAwait(false);
         }
 
         #region 审批事件
@@ -732,7 +732,9 @@ namespace Senparc.Weixin.Work.MessageHandlers
                 case ThirdPartyInfo.CHANGE_CONTACT:
                     return OnThirdPartyEvent_Change_ContactAsync((RequestMessageInfo_Change_Contact)thirdPartyInfo);
                 case ThirdPartyInfo.REGISTER_CORP:
-                    return OnThirdPartyEvent_REGISTER_CORPAsync((RequestMessager_Register_Corp)thirdPartyInfo);
+                    return OnThirdPartyEvent_Register_CorpAsync((RequestMessager_Register_Corp)thirdPartyInfo);
+                case ThirdPartyInfo.RESET_PERMANENT_CODE:
+                    return OnThirdPartEvent_Reset_Permanent_CodeAsync((RequestMessageInfo_Reset_Permanent_Code)thirdPartyInfo);
                 case ThirdPartyInfo.CHANGE_EXTERNAL_CONTACT:
                 {
                     var cecRequestMessage = RequestMessage as IRequestMessageEvent_Change_ExternalContact_Base;
@@ -772,34 +774,46 @@ namespace Senparc.Weixin.Work.MessageHandlers
             return await Task.Run(() => OnThirdPartyEvent_Change_Contact(thirdPartyInfo)).ConfigureAwait(false);
         }
 
-        protected virtual async Task<string> OnThirdPartyEvent_REGISTER_CORPAsync(
+        protected virtual async Task<string> OnThirdPartyEvent_Register_CorpAsync(
             RequestMessager_Register_Corp thirdPartyInfo)
         {
-            return await Task.Run(() => OnThirdPartyEvent_REGISTER_CORPAsync(thirdPartyInfo)).ConfigureAwait(false);
+            return await Task.Run(() => OnThirdPartyEvent_Register_Corp(thirdPartyInfo)).ConfigureAwait(false);
+        }
+
+        [Obsolete("请使用修复拼写之后的方法:OnThirdPartyEvent_Register_CorpAsync", true)]
+        protected virtual Task<string> OnThirdPartyEvent_REGISTER_CORPAsync(
+            RequestMessager_Register_Corp thirdPartyInfo)
+        {
+            return OnThirdPartyEvent_Register_CorpAsync(thirdPartyInfo);
         }
 
         protected virtual async Task<string> OnThirdPartyEvent_Create_AuthAsync(
             RequestMessageInfo_Create_Auth thirdPartyInfo)
         {
-            return await Task.Run(() => OnThirdPartyEvent_Create_AuthAsync(thirdPartyInfo)).ConfigureAwait(false);
+            return await Task.Run(() => OnThirdPartyEvent_Create_Auth(thirdPartyInfo)).ConfigureAwait(false);
         }
 
         protected virtual async Task<string> OnThirdPartyEvent_Cancel_AuthAsync(
             RequestMessageInfo_Cancel_Auth thirdPartyInfo)
         {
-            return await Task.Run(() => OnThirdPartyEvent_Cancel_AuthAsync(thirdPartyInfo)).ConfigureAwait(false);
+            return await Task.Run(() => OnThirdPartyEvent_Cancel_Auth(thirdPartyInfo)).ConfigureAwait(false);
         }
 
         protected virtual async Task<string> OnThirdPartyEvent_Change_AuthAsync(
             RequestMessageInfo_Change_Auth thirdPartyInfo)
         {
-            return await Task.Run(() => OnThirdPartyEvent_Change_AuthAsync(thirdPartyInfo)).ConfigureAwait(false);
+            return await Task.Run(() => OnThirdPartyEvent_Change_Auth(thirdPartyInfo)).ConfigureAwait(false);
         }
 
         protected virtual async Task<string> OnThirdPartyEvent_Suite_TicketAsync(
             RequestMessageInfo_Suite_Ticket thirdPartyInfo)
         {
-            return await Task.Run(() => OnThirdPartyEvent_Suite_TicketAsync(thirdPartyInfo)).ConfigureAwait(false);
+            return await Task.Run(() => OnThirdPartyEvent_Suite_Ticket(thirdPartyInfo)).ConfigureAwait(false);
+        }
+
+        protected virtual async Task<string> OnThirdPartEvent_Reset_Permanent_CodeAsync(RequestMessageInfo_Reset_Permanent_Code thirdPartyInfo)
+        {
+            return await Task.Run(() => OnThirdPartEvent_ResetPermanentCode(thirdPartyInfo)).ConfigureAwait(false);
         }
 
         #region 外部联系人

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/MessageHandlers/WorkMessageHandler.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/MessageHandlers/WorkMessageHandler.cs
@@ -1,4 +1,4 @@
-﻿/*----------------------------------------------------------------
+/*----------------------------------------------------------------
     Copyright (C) 2023 Senparc
     
     文件名：WorkMessageHandler.cs
@@ -248,7 +248,7 @@ namespace Senparc.Weixin.Work.MessageHandlers
             {
                 requestDocument = postDataDocument;//TODO:深拷贝
             }
-            
+
             RequestMessage = RequestMessageFactory.GetRequestEntity<TMC>(new TMC(), doc: requestDocument);
 
             return requestDocument;
@@ -889,7 +889,13 @@ namespace Senparc.Weixin.Work.MessageHandlers
             return ThirdPartyEventSuccessResult;
         }
 
+        [Obsolete("请使用修复拼写之后的方法:OnThirdPartyEvent_Register_Corp", true)]
         protected virtual string OnThirdPartyEvent_REGISTER_CORP(RequestMessager_Register_Corp thirdPartyInfo)
+        {
+            return OnThirdPartyEvent_Register_Corp(thirdPartyInfo);
+        }
+
+        protected virtual string OnThirdPartyEvent_Register_Corp(RequestMessager_Register_Corp thirdPartyInfo)
         {
             return ThirdPartyEventSuccessResult;
         }
@@ -910,6 +916,11 @@ namespace Senparc.Weixin.Work.MessageHandlers
         }
 
         protected virtual string OnThirdPartyEvent_Suite_Ticket(RequestMessageInfo_Suite_Ticket thirdPartyInfo)
+        {
+            return ThirdPartyEventSuccessResult;
+        }
+
+        protected virtual string OnThirdPartEvent_ResetPermanentCode(RequestMessageInfo_Reset_Permanent_Code requestMessage)
         {
             return ThirdPartyEventSuccessResult;
         }

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/RequestMessageFactory.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/RequestMessageFactory.cs
@@ -1,4 +1,4 @@
-﻿/*----------------------------------------------------------------
+/*----------------------------------------------------------------
     Copyright (C) 2023 Senparc
   
     文件名：RequestMessageFactory.cs
@@ -100,6 +100,9 @@ namespace Senparc.Weixin.Work
                             break;
                         case ThirdPartyInfo.CHANGE_CONTACT://通讯录变更通知
                             requestMessage = new RequestMessageInfo_Change_Contact();
+                            break;
+                        case ThirdPartyInfo.RESET_PERMANENT_CODE:
+                            requestMessage = new RequestMessageInfo_Reset_Permanent_Code();
                             break;
                         case ThirdPartyInfo.CHANGE_EXTERNAL_CONTACT:
                             switch (doc.Root.Element("ChangeType").Value.ToUpper())


### PR DESCRIPTION
1. 修复Async方法循环调用的Bug
2. 增加三方操作: RESET_PERMANENT_CODE
3. REGISTER_CORP处理事件明明问题修复(破坏性变更， 已做提示，再更新编译时报错，提示需要修复)