### PR TITLE
Senparc.Weixin.Open.OAuthAPIs 返回值添加参数 is_snapshotuser 和 unionid

### DIFF
--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/OAuthAPIs/OAuthJson/OAuthAccessTokenResult.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/OAuthAPIs/OAuthJson/OAuthAccessTokenResult.cs
@@ -45,6 +45,10 @@ namespace Senparc.Weixin.Open.OAuthAPIs
         /// </summary>
         public string scope { get; set; }
         /// <summary>
+        /// 用户统一标识（针对一个微信开放平台账号下的应用，同一用户的 unionid 是唯一的），只有当scope为"snsapi_userinfo"时返回
+        /// </summary>
+        public string unionid { get; set; }
+        /// <summary>
         /// 是否为快照页模式虚拟账号，只有当用户是快照页模式虚拟账号是返回，值为1
         /// </summary>
         public int? is_snapshotuser { get; set; }

--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/OAuthAPIs/OAuthJson/OAuthAccessTokenResult.cs
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/OAuthAPIs/OAuthJson/OAuthAccessTokenResult.cs
@@ -44,5 +44,9 @@ namespace Senparc.Weixin.Open.OAuthAPIs
         /// 用户授权的作用域，使用逗号（,）分隔
         /// </summary>
         public string scope { get; set; }
+        /// <summary>
+        /// 是否为快照页模式虚拟账号，只有当用户是快照页模式虚拟账号是返回，值为1
+        /// </summary>
+        public int? is_snapshotuser { get; set; }
     }
 }


### PR DESCRIPTION
第三方平台网页授权返回值也增加了  is_snapshotuser 和  unionid参数
https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_webpage_authorization.html

`{
"access_token":"86_8ltlLHY7eIXre1qb8XAL3MyiiVIqCPAOM4t6A077MzI-Q",
"expires_in":7200,
"refresh_token":"86_4_m8T_72NxQwfROhxC0FjA-9ChOyTblGB69pQ",
"openid":"oUSqc6cEcBI2fiO76sZDVgSVN0rY",
"scope":"snsapi_userinfo",
"unionid":"oeA830tP2C2EzJPoSBQBdCNg8Iw0",
"is_snapshotuser":1
}
`



![image](https://github.com/user-attachments/assets/2cbe9dea-d0f4-41e0-b3a1-23f2ebe6866c)
