### PR TITLE
Feature/完善微信公众号对话机器人服务

### DIFF
--- a/Samples/All/Senparc.Weixin.Sample.CommonService/AI/MessageHandlers/ChatStore.cs
+++ b/Samples/All/Senparc.Weixin.Sample.CommonService/AI/MessageHandlers/ChatStore.cs
@@ -36,10 +36,16 @@ namespace Senparc.Weixin.MP.Sample.CommonService.AI.MessageHandlers
 
         public List<WeixinAiChatHistory> History { get; set; }
 
+        /// <summary>
+        /// 是否使用Markdown格式输出
+        /// </summary>
+        public bool UseMarkdown { get; set; }
+
         public ChatStore()
         {
             Status = ChatStatus.None;
             MultimodelType = MultimodelType.None;
+            UseMarkdown = true;
         }
 
         public ChatHistory GetChatHistory()

--- a/Samples/All/Senparc.Weixin.Sample.CommonService/AI/MessageHandlers/CustomMessageHandler_AI.cs
+++ b/Samples/All/Senparc.Weixin.Sample.CommonService/AI/MessageHandlers/CustomMessageHandler_AI.cs
@@ -42,6 +42,7 @@ namespace Senparc.Weixin.Sample.CommonService.CustomMessageHandler
 输入“p”暂停，可以暂时保留记忆
 输入“e”退出，彻底删除记忆
 输入“m”可以进入多模态对话模式（根据语义自动生成文字+图片）
+输入“t”可以从多模态进入纯文本对话模式
 输入“img 文字”可以强制生成图片，例如：img 一只猫
 
 [结果由 AI 生成，仅供参考]";
@@ -156,7 +157,7 @@ namespace Senparc.Weixin.Sample.CommonService.CustomMessageHandler
                         judgeMultimodel = true;
                     }
 
-                    if (chatStore.Status == oldChatStatus)
+                    if (chatStore.Status == oldChatStatus && chatStore.MultimodelType == MultimodelType.SimpleChat)// 在文字对话的状态下，才能切换到多模态对话
                     {
                         if (requestMessageText.Content.Equals("M", StringComparison.OrdinalIgnoreCase))
                         {
@@ -177,6 +178,15 @@ namespace Senparc.Weixin.Sample.CommonService.CustomMessageHandler
                             {
                                 prompt = "img " + prompt;//添加 img 前缀
                             }
+                        }
+                        else if (requestMessageText.Content.Equals("T", StringComparison.OrdinalIgnoreCase) && chatStore.MultimodelType == MultimodelType.ChatAndImage)
+                        {
+                            //切换到纯文字对话
+                            chatStore.MultimodelType = MultimodelType.SimpleChat;
+                            await UpdateMessageContextAsync(currentMessageContext, chatStore);
+                            var responseMessage = base.CreateResponseMessage<ResponseMessageText>();
+                            responseMessage.Content = "已切换到纯文字对话模式！AI 将用纯文字回复";
+                            return responseMessage;
                         }
                     }
 

--- a/Samples/All/net8-mvc/Senparc.Weixin.Sample.Net8/appsettings.json
+++ b/Samples/All/net8-mvc/Senparc.Weixin.Sample.Net8/appsettings.json
@@ -86,7 +86,7 @@
     //如果不设置TenPayV3_WxOpenTenpayNotify，默认在 TenPayV3_TenpayNotify 的值最后加上 "WxOpen"
     "TenPayV3_WxOpenTenpayNotify": "#{TenPayV3_WxOpenTenpayNotify}#", //http://YourDomainName/TenpayV3/PayNotifyUrlWxOpen
 
-    "EncryptionType": "#{EncryptionType}#", // 加密类型：RSA / SM（必填，根据后台申请证书类型选择，大部分情况为 RSA）
+    "EncryptionType": "RSA", // 加密类型：RSA / SM（必填，根据后台申请证书类型选择，大部分情况为 RSA）
 
     //开放平台
     "Component_Appid": "#{Component_Appid}#",

--- a/Samples/All/net8-mvc/Senparc.Weixin.Sample.Net8/appsettings.json
+++ b/Samples/All/net8-mvc/Senparc.Weixin.Sample.Net8/appsettings.json
@@ -86,7 +86,7 @@
     //如果不设置TenPayV3_WxOpenTenpayNotify，默认在 TenPayV3_TenpayNotify 的值最后加上 "WxOpen"
     "TenPayV3_WxOpenTenpayNotify": "#{TenPayV3_WxOpenTenpayNotify}#", //http://YourDomainName/TenpayV3/PayNotifyUrlWxOpen
 
-    "EncryptionType": "RSA", // 加密类型：RSA / SM（必填，根据后台申请证书类型选择，大部分情况为 RSA）
+    "EncryptionType": "#{EncryptionType}#", // 加密类型：RSA / SM（必填，根据后台申请证书类型选择，大部分情况为 RSA）
 
     //开放平台
     "Component_Appid": "#{Component_Appid}#",


### PR DESCRIPTION
### feat1.
为微信公众号AI对话机器人添加从多模态对话回到文字对话的功能，用户可以输入“t"从多模态切换回纯文字输出
- 在CustomMessageHandler_AI中添加"t"命令支持,输入"t"可在多模态状态下切换回纯文字输出
- 更新欢迎消息，提示用户可用的命令
### feat2
为微信公众号AI对话机器人添加Markdown格式输出控制功能
- 在CustomMessageHandler_AI中添加dm/md命令支持
  - 输入'dm'可关闭Markdown格式输出，使用纯文本回复
  - 输入'md'可恢复Markdown格式输出
- 根据UseMarkdown状态为AI对话添加相应的格式前缀
- 更新欢迎消息，提示用户可用的命令