### PR TITLE
Feature/完善微信公众号对话机器人服务

### DIFF
--- a/Samples/All/Senparc.Weixin.Sample.CommonService/AI/MessageHandlers/CustomMessageHandler_AI.cs
+++ b/Samples/All/Senparc.Weixin.Sample.CommonService/AI/MessageHandlers/CustomMessageHandler_AI.cs
@@ -196,7 +196,7 @@ namespace Senparc.Weixin.Sample.CommonService.CustomMessageHandler
                         await UpdateMessageContextAsync(currentMessageContext, chatStore);
 
                         var responseMessage = base.CreateResponseMessage<ResponseMessageText>();
-                        responseMessage.Content = "已开启长对话模式！AI将在对话每到达最大历史对话轮数（默认10轮）后，会自动整理对话记忆，并清空对话历史，再次输入lc以关闭";
+                        responseMessage.Content = chatStore.UseLongChat ? "已开启长对话模式！AI将在对话每到达最大历史对话轮数（默认10轮）后，会自动整理对话记忆，并清空对话历史，再次输入lc以关闭" : "已关闭长对话模式！AI将不再自动整理对话记忆，并清空对话历史，再次输入lc以开启";
                         return responseMessage;
                     }
 

--- a/Samples/All/Senparc.Weixin.Sample.CommonService/MessageHandlers/CustomMessageHandler/CustomMessageHandler.cs
+++ b/Samples/All/Senparc.Weixin.Sample.CommonService/MessageHandlers/CustomMessageHandler/CustomMessageHandler.cs
@@ -270,7 +270,7 @@ namespace Senparc.Weixin.Sample.CommonService.CustomMessageHandler
                      * 这是一个特殊的过程，此请求通常来自于微微嗨（http://www.weiweihi.com）的“盛派网络小助手”应用请求（https://www.weiweihi.com/User/App/Detail/1），
                      * 用于演示微微嗨应用商店的处理过程，由于微微嗨的应用内部可以单独设置对话过期时间，所以这里通常不需要考虑对话状态，只要做最简单的响应。
                      */
-                    if (defaultResponseMessage.Content == "测试")
+                    if (requestMessage.Content == "测试")
                     {
                         //进入APP测试
                         defaultResponseMessage.Content = "您已经进入【盛派网络小助手】的测试程序，请发送任意信息进行测试。发送文字【退出】退出测试对话。10分钟内无任何交互将自动退出应用对话状态。";


### PR DESCRIPTION
feat: 新增AI对话长对话模式及记忆整理功能

## 功能概述
为微信公众号AI对话机器人新增长对话模式支持，实现智能记忆整理和对话历史管理。

## 详细实现

### 1. 数据模型扩展 (ChatStore.cs)
- 新增 UseLongChat 属性：控制是否启用长对话模式
- 新增 LastStoredMemory 属性：存储AI整理后的对话记忆
- 新增 LastStoredPrompt 属性：记录上一次用户提问内容
- 在构造函数中设置 UseLongChat = false 作为默认值

### 2. 核心功能实现 (CustomMessageHandler_AI.cs)

#### 2.1 长对话模式控制
- 新增 lc 命令：用户可输入lc开启/关闭长对话模式
- 实现 longChatFunc 委托：检测长对话模式切换命令

#### 2.2 智能记忆整理机制
- 新增 ConsolidateMemoryAsync 方法：
  - 监控AI消息数量，当达到10条时触发记忆整理
  - 用LastStoredMemory作为记忆整理的systemPrompt,记忆里添加上一次提问的问题，这样才能保证流畅对话
  - 使用AI模型总结用户需求、偏好、关键信息点、之前聊天的内容
  - 将整理后的记忆保存到LastStoredMemory
  - 清空历史对话记录

#### 2.3 记忆驱动的对话系统
- 修改 TextChatAsync 方法：
  - 如果开启了长对话模式，那么尝试调用 ConsolidateMemoryAsync 进行记忆整理
  - 使用整理后的记忆作为SystemMessage，如果ConsolidateMemoryAsync返回值为空（即没有生成记忆，也没有历史记忆），那么使用系统默认的SystemMessage
  - 更新 LastStoredPrompt 记录当前提问，这是为了让对话可以流畅进行

### 4. 使用方式
用户输入lc开启长对话模式后：
- 对话达到10轮时自动整理记忆
- AI会总结用户需求并保存为记忆
- 清空历史记录，把记忆作为SystemMessage,继续新的对话
- 再次输入lc可关闭长对话模式

## 影响范围
- 修改文件：ChatStore.cs, CustomMessageHandler_AI.cs
- 新增功能：长对话模式、记忆整理、智能状态管理
- 向后兼容：不影响现有功能，默认关闭长对话模式


fix.修复了“测试”消息无法正确触发的问题

原代码中把`requestMessage.Content == "测试"`误写成了`defaultResponseMessage.Content == "测试"`，导致发送“测试”时会收到`"您已退出【盛派网络小助手】的测试程序。"`的消息，现已修复。