### PR TITLE
Feature/完善企业微信智能体（智能机器人）服务

### DIFF
--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/JSONMsgCryptTest.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/JSONMsgCryptTest.cs
@@ -1,0 +1,106 @@
+#region Apache License Version 2.0
+/*----------------------------------------------------------------
+
+Copyright 2025 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
+
+----------------------------------------------------------------*/
+#endregion Apache License Version 2.0
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Senparc.Weixin.Work.Tencent;
+using Senparc.Weixin.Work;
+using Senparc.Weixin.Work.Entities;
+using Senparc.Weixin.Work.Helpers;
+using Senparc.CO2NET.Helpers;
+using Senparc.CO2NET.Extensions;
+
+
+//本测试代码用于测试企业微信的加解密算法，同时用于生成一个加密的请求消息示例，以方便其他开发人员使用。
+namespace Senparc.Weixin.Work.Test
+{
+    [TestClass]
+    public class JSONMsgCryptTest
+    {
+        public string sToken = "QDG6eK";
+        public string sEncodingAESKey = "jWmYm7qr5nMoAUwZRjGtBxmz3KA1tkAj3ykkR6q2B2C";
+
+        string sReqTimeStamp = "1409659813";
+        string sReqNonce = "1372623149";
+
+        public BotRequestMessageText botRequestMessageText = new BotRequestMessageText();
+
+        [TestMethod]
+        public void TestMethod()
+        {
+            ////加解密库要求传 receiveid 参数，企业自建智能机器人的使用场景里，receiveid直接传空字符串即可
+            WXBizMsgCrypt wxcpt = new WXBizMsgCrypt(sToken, sEncodingAESKey, "");
+
+            //模拟一个请求消息
+            botRequestMessageText.text = new BotRequestMessageText.Text();
+            botRequestMessageText.text.content = "test";
+            botRequestMessageText.from = new BotRequestMessageText.From();
+            botRequestMessageText.from.userid = "test";
+            botRequestMessageText.aibotid = "12345";
+            botRequestMessageText.msgid = "1234567890123456";
+            botRequestMessageText.chatid = "1234567890123456";
+
+            var json = botRequestMessageText.ToJson(true);
+            
+
+            //加密出来的密文
+            string sEncryptMsg = "";
+
+            var encryptMsg = wxcpt.EncryptJsonMsg(json, sReqTimeStamp, sReqNonce, ref sEncryptMsg);
+
+            System.Console.WriteLine(sEncryptMsg);
+
+            /*
+            这是加密过后的得到的密文，是请求消息不是回复消息，接下来测试请求消息的解密
+             {"encrypt":"6RS0Ko1VsJN/WaFfxqhNGUtb8r2UxTNONDi2rnT8wc4ArAKL3DATSe52RWiPtCpMyIFp9wpXdjhNCPcc6TD8n31lGWsLSZeLt0qq8f+XoRDvVkp6Ma+SZjZsFrq8Tays8ugQ0O1XYJXBdHm4RIkKu2uYgXd+rYwwqi6KiXSh+YX2UJRESFyP9mflQf7HeKLK7eRjIyYUNDASVD3c6JKzGXtzC3G9/Gxjiez9r39XvlaJJzQmsqjSraC9o7Io1ny9E6G8pY5udbdiWyB4MFbrPXJ5tEEiHaIK2WYn7ZqxvRLvuvK/pMoLfDw6O1E2+NZCbkfyzEvWLM4mZnwhzj5Hhg==","msgsignature":"f490df6179b86bcaf6fbed0bf32166a477ca6c86","timestamp":"1409659813","nonce":"1372623149"}
+            */
+
+            string sig = "f490df6179b86bcaf6fbed0bf32166a477ca6c86";
+
+            //解密出来的原文
+            string sMsg = "";
+
+            string encrypt = """
+            {"encrypt":"6RS0Ko1VsJN/WaFfxqhNGUtb8r2UxTNONDi2rnT8wc4ArAKL3DATSe52RWiPtCpMyIFp9wpXdjhNCPcc6TD8n31lGWsLSZeLt0qq8f+XoRDvVkp6Ma+SZjZsFrq8Tays8ugQ0O1XYJXBdHm4RIkKu2uYgXd+rYwwqi6KiXSh+YX2UJRESFyP9mflQf7HeKLK7eRjIyYUNDASVD3c6JKzGXtzC3G9/Gxjiez9r39XvlaJJzQmsqjSraC9o7Io1ny9E6G8pY5udbdiWyB4MFbrPXJ5tEEiHaIK2WYn7ZqxvRLvuvK/pMoLfDw6O1E2+NZCbkfyzEvWLM4mZnwhzj5Hhg=="}
+            """;
+
+            //解密
+            var decryptMsg = wxcpt.DecryptJsonMsg(sig, sReqTimeStamp, sReqNonce, encrypt, ref sMsg);
+            System.Console.WriteLine(sMsg);
+
+            //原文
+            string originalMsg = """
+        {
+          "msgtype": "text",
+          "text": {
+            "content": "test"
+          },
+          "msgid": "1234567890123456",
+          "aibotid": "12345",
+          "chatid": "1234567890123456",
+          "chattype": null,
+          "from": {
+            "userid": "test"
+          }
+        }
+        """;
+            Assert.AreEqual(originalMsg, sMsg);
+        }
+    }
+}

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/MessageHandlers/BotCustomMessageHandler.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/MessageHandlers/BotCustomMessageHandler.cs
@@ -1,0 +1,41 @@
+using Senparc.NeuChar;
+using Senparc.NeuChar.ApiHandlers;
+using Senparc.NeuChar.MessageHandlers;
+using Senparc.Weixin.Work.Entities;
+using Senparc.Weixin.Work.Helpers;
+using Senparc.Weixin.Work.MessageHandlers;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Senparc.Weixin.Work.Test.net6.MessageHandlers
+{
+    public class BotCustomMessageHandler : WorkBotMessageHandler<MessageContexts.DefaultWorkMessageContext>
+    {
+        public BotCustomMessageHandler(Stream inputStream, IEncryptPostModel postModel, int maxRecordCount = 0, bool onlyAllowEncryptMessage = false, IServiceProvider serviceProvider = null) : base(inputStream, postModel, maxRecordCount, onlyAllowEncryptMessage, serviceProvider)
+        {
+        }
+
+        public override MessageEntityEnlightener MessageEntityEnlightener => throw new NotImplementedException();
+
+        public override ApiEnlightener ApiEnlightener => throw new NotImplementedException();
+
+        public override XDocument ResponseDocument => throw new NotImplementedException();
+
+        public override XDocument FinalResponseDocument => throw new NotImplementedException();
+
+        public override IWorkResponseMessageBase DefaultResponseMessage(IWorkRequestMessageBase requestMessage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override XDocument Init(XDocument requestDocument, IEncryptPostModel postModel)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/MessageHandlers/BotCustomMessageHandler.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/MessageHandlers/BotCustomMessageHandler.cs
@@ -16,7 +16,7 @@ namespace Senparc.Weixin.Work.Test.net6.MessageHandlers
 {
     public class BotCustomMessageHandler : WorkBotMessageHandler<MessageContexts.DefaultWorkMessageContext>
     {
-        public BotCustomMessageHandler(Stream inputStream, IEncryptPostModel postModel, int maxRecordCount = 0, bool onlyAllowEncryptMessage = false, IServiceProvider serviceProvider = null) : base(inputStream, postModel, maxRecordCount, onlyAllowEncryptMessage, serviceProvider)
+        public BotCustomMessageHandler(Stream inputStream, IEncryptPostModel postModel, int maxRecordCount = 0, bool onlyAllowEncryptMessage = false, IServiceProvider serviceProvider = null, bool useJson = true) : base(inputStream, postModel, maxRecordCount, onlyAllowEncryptMessage, serviceProvider, useJson)
         {
         }
 
@@ -30,9 +30,13 @@ namespace Senparc.Weixin.Work.Test.net6.MessageHandlers
 
         public override IWorkResponseMessageBase DefaultResponseMessage(IWorkRequestMessageBase requestMessage)
         {
-            throw new NotImplementedException();
+            var responseMessage = CreateResponseMessage<ResponseMessageText>();
+            responseMessage.Content = "这是一条默认消息。";
+            return responseMessage;
         }
 
+
+        //仅是为了实现抽象类不报错，不做使用
         public override XDocument Init(XDocument requestDocument, IEncryptPostModel postModel)
         {
             throw new NotImplementedException();

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/MessageHandlers/BotCustomMessageHandler.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/MessageHandlers/BotCustomMessageHandler.cs
@@ -20,9 +20,9 @@ namespace Senparc.Weixin.Work.Test.net6.MessageHandlers
         {
         }
 
-        public override MessageEntityEnlightener MessageEntityEnlightener => throw new NotImplementedException();
-
-        public override ApiEnlightener ApiEnlightener => throw new NotImplementedException();
+        public BotCustomMessageHandler(string postDataJson, IEncryptPostModel postModel, int maxRecordCount = 0, bool onlyAllowEncryptMessage = false, IServiceProvider serviceProvider = null) : base(postDataJson, postModel, maxRecordCount, onlyAllowEncryptMessage, serviceProvider)
+        {
+        }
 
         public override XDocument ResponseDocument => throw new NotImplementedException();
 

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/MessageHandlers/BotMessageHandlerTest.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work.Test/MessageHandlers/BotMessageHandlerTest.cs
@@ -1,0 +1,68 @@
+#region Apache License Version 2.0
+/*----------------------------------------------------------------
+
+Copyright 2025 Jeffrey Su & Suzhou Senparc Network Technology Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Detail: https://github.com/JeffreySu/WeiXinMPSDK/blob/master/license.md
+
+----------------------------------------------------------------*/
+#endregion Apache License Version 2.0
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Senparc.Weixin.Work.Entities;
+using Senparc.Weixin.Work.Test.CommonApis;
+using Senparc.Weixin.Work.Test.net6.MessageHandlers;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Senparc.Weixin.Work.Test.MessageHandlers
+{
+    [TestClass]
+    public class BotMessageHandlerTest : CommonApiTest
+    {
+        public string testJSON = """
+        {"encrypt":"6RS0Ko1VsJN/WaFfxqhNGUtb8r2UxTNONDi2rnT8wc4ArAKL3DATSe52RWiPtCpMyIFp9wpXdjhNCPcc6TD8n31lGWsLSZeLt0qq8f+XoRDvVkp6Ma+SZjZsFrq8Tays8ugQ0O1XYJXBdHm4RIkKu2uYgXd+rYwwqi6KiXSh+YX2UJRESFyP9mflQf7HeKLK7eRjIyYUNDASVD3c6JKzGXtzC3G9/Gxjiez9r39XvlaJJzQmsqjSraC9o7Io1ny9E6G8pY5udbdiWyB4MFbrPXJ5tEEiHaIK2WYn7ZqxvRLvuvK/pMoLfDw6O1E2+NZCbkfyzEvWLM4mZnwhzj5Hhg=="}
+        """;
+        [TestMethod]
+        public async Task TestMethod()
+        {
+            var postModel = new PostModel()
+            {
+                Msg_Signature = "f490df6179b86bcaf6fbed0bf32166a477ca6c86",
+                Timestamp = "1409659813",
+                Nonce = "1372623149",
+
+                Token = "QDG6eK",
+                EncodingAESKey = "jWmYm7qr5nMoAUwZRjGtBxmz3KA1tkAj3ykkR6q2B2C",
+            };
+            var messageHandler = new BotCustomMessageHandler(testJSON, postModel, 10);
+
+            System.Console.WriteLine(messageHandler.RequestJsonStr);
+            Assert.IsNotNull(messageHandler.RequestJsonStr);
+            Assert.IsNotNull(messageHandler.RequestMessage);
+            Assert.IsNotNull(messageHandler.MessageEntityEnlightener);
+            Assert.IsNotNull(messageHandler.RequestMessage.GetRepeatedBusiness);
+            System.Console.WriteLine(messageHandler.MessageEntityEnlightener.PlatformType.ToString());
+
+            await messageHandler.ExecuteAsync(new CancellationToken());
+
+            System.Console.WriteLine(messageHandler.ResponseJsonStr);
+            Assert.IsNotNull(messageHandler.ResponseJsonStr);
+            Assert.IsNotNull(messageHandler.ResponseMessage);
+
+            System.Console.WriteLine(messageHandler.FinalResponseJsonStr);
+            Assert.IsNotNull(messageHandler.FinalResponseJsonStr);
+        }
+    }
+}

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Helpers/BotEntityHelper.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Helpers/BotEntityHelper.cs
@@ -31,31 +31,37 @@ namespace Senparc.Weixin.Work.Helpers
 
 
         /// <summary>
-        /// 为请求消息设置公共字段
+        /// 创建请求实例并为请求消息设置公共字段
         /// </summary>
+        /// <typeparam name="T">请求消息实体类型</typeparam>
         /// <param name="requestMessage">请求消息实体</param>
         /// <param name="baseMessage">基础消息对象</param>
-        private static void SetRequestCommonFields(WorkRequestMessageBase requestMessage, WorkBotRequestMessageBase baseMessage)
+        private static T SetRequestCommonProperties<T>(WorkBotRequestMessageBase baseMessage) where T : WorkRequestMessageBase, new()
         {
+            var requestMessage = new T();
             requestMessage.FromUserName = baseMessage.from.userid;
             requestMessage.ToUserName = baseMessage.aibotid;
             requestMessage.MsgId = baseMessage.msgid;
+            return requestMessage;
         }
 
         /// <summary>
         /// 为回复消息设置公共字段
         /// </summary>
+        /// <typeparam name="T">回复消息实体类型</typeparam>
         /// <param name="responseMessage">回复消息实体</param>
         /// <param name="baseMessage">基础消息对象</param>
         /// <remarks>
         /// 注意：由于WorkResponseMessageBase的MsgType属性是只读的，
         /// 每个具体的响应消息类型会在自己的类中重写MsgType属性来设置正确的类型
         /// </remarks>
-        private static void SetResponseCommonFields(WorkResponseMessageBase responseMessage, WorkBotResponseMessageBase baseMessage)
+        private static T SetResponseCommonProperties<T>(WorkBotResponseMessageBase baseMessage) where T : WorkResponseMessageBase, new()
         {
+            var responseMessage = new T();
             // 目前回复消息的公共字段只有msgtype，但这个字段由各个子类自己设置
             // 这里可以设置其他公共字段（如果将来有的话）
             // responseMessage.CreateTime = DateTime.Now; // 示例
+            return responseMessage;
         }
 
 
@@ -75,10 +81,7 @@ namespace Senparc.Weixin.Work.Helpers
             {
                 // 直接创建 RequestMessageText 实例
                 var textJsonObject = SerializerHelper.GetObject<BotRequestMessageText>(json);
-                var textRequestMessage = new RequestMessageText();
-                
-                //为共有字段赋值
-                SetRequestCommonFields(textRequestMessage, baseMessage);
+                var textRequestMessage = SetRequestCommonProperties<RequestMessageText>(baseMessage);
                 
                 // 对特有属性赋值   
                 textRequestMessage.Content = textJsonObject.text.content;
@@ -90,10 +93,9 @@ namespace Senparc.Weixin.Work.Helpers
                 {
                     case RequestMsgType.Image:
                         var imageJsonObject = SerializerHelper.GetObject<BotRequestMessageImage>(json);
-                        var imageRequestMessage = new RequestMessageImage();
-                        
-                        //为共有字段赋值
-                        SetRequestCommonFields(imageRequestMessage, baseMessage);
+
+                        //创建请求消息实体,并设置共有字段
+                        var imageRequestMessage = SetRequestCommonProperties<RequestMessageImage>(baseMessage);
                         
                         // 对特有属性赋值   
                         imageRequestMessage.PicUrl = imageJsonObject.image.url;
@@ -105,20 +107,19 @@ namespace Senparc.Weixin.Work.Helpers
                         {
                             case "enter_chat":
                                 var enterChatJsonObject = SerializerHelper.GetObject<BotRequestMessageEvent_Enter>(json);
-                                var enterChatRequestMessage = new RequestMessageEvent_Enter_Agent();
+
+                                //创建请求消息实体,并设置共有字段
+                                var enterChatRequestMessage = SetRequestCommonProperties<RequestMessageEvent_Enter_Agent>(baseMessage);
                                 
-                                //为共有字段赋值
-                                SetRequestCommonFields(enterChatRequestMessage, baseMessage);
                                 
                                 // 对特有属性赋值   
                                 requestMessage = enterChatRequestMessage;
                                 break;
                             case "template_card_event":
                                 var templateCardEventJsonObject = SerializerHelper.GetObject<BotRequestMessageEvent_TemplateCardEvent>(json);
-                                var templateCardEventRequestMessage = new RequestMessageEvent_TemplateCardEvent();
-                                
-                                //为共有字段赋值
-                                SetRequestCommonFields(templateCardEventRequestMessage, baseMessage);
+
+                                //创建请求消息实体,并设置共有字段
+                                var templateCardEventRequestMessage = SetRequestCommonProperties<RequestMessageEvent_TemplateCardEvent>(baseMessage);
                                 
                                 // 对特有属性赋值   
                                 requestMessage = templateCardEventRequestMessage;
@@ -175,10 +176,9 @@ namespace Senparc.Weixin.Work.Helpers
             {
                 case ResponseMsgType.Text:
                     var textJsonObject = SerializerHelper.GetObject<BotResponseMessageText>(json);
-                    var textResponseMessage = new ResponseMessageText();
-                    
-                    //为共有字段赋值
-                    SetResponseCommonFields(textResponseMessage, baseMessage);
+
+                    //创建回复消息实体,并设置共有字段
+                    var textResponseMessage = SetResponseCommonProperties<ResponseMessageText>(baseMessage);
                     
                     // 对特有属性赋值
                     textResponseMessage.Content = textJsonObject?.text?.content;
@@ -194,10 +194,7 @@ namespace Senparc.Weixin.Work.Helpers
                 // TODO: 添加模板卡片类型的处理,但是目前NeuChar标准中没有对应枚举，需要补充
                 // case ResponseMsgType.TemplateCard:
                 //     var templateCardJsonObject = SerializerHelper.GetObject<BotResponseMessageTemplateCard>(json);
-                //     var templateCardResponseMessage = new ResponseMessageTemplateCard();
-                //     
-                //     //为共有字段赋值
-                //     SetResponseCommonFields(templateCardResponseMessage, baseMessage);
+                //     var templateCardResponseMessage = SetResponseCommonProperties<ResponseMessageTemplateCard>(baseMessage);
                 //     
                 //     // 对特有属性赋值
                 //     // TODO: 根据 templateCardJsonObject 设置特有属性

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/MessageHandlers/Async/WorkBotMessageHandler.Async.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/MessageHandlers/Async/WorkBotMessageHandler.Async.cs
@@ -1,0 +1,58 @@
+/*----------------------------------------------------------------
+    Copyright (C) 2025 Senparc
+
+    文件名：WorkBotMessageHandler.Async.cs
+    文件功能描述：企业号智能机器人请求的集中处理方法
+
+
+    创建标识：Wang Qian - 20250825
+----------------------------------------------------------------*/
+
+using Senparc.NeuChar.Context;
+using Senparc.Weixin.Exceptions;
+using Senparc.NeuChar.MessageHandlers;
+using Senparc.Weixin.Work.Entities;
+using Senparc.NeuChar;
+using System.Threading.Tasks;
+using System.Threading;
+using Senparc.Weixin.Work.Entities.Request.Event;
+using System;
+
+namespace Senparc.Weixin.Work.MessageHandlers
+{
+    public abstract partial class WorkBotMessageHandler<TMC>
+        : MessageHandler<TMC, IWorkRequestMessageBase, IWorkResponseMessageBase>, IWorkBotMessageHandler
+        where TMC : class, IMessageContext<IWorkRequestMessageBase, IWorkResponseMessageBase>, new()
+        {
+            public override async Task BuildResponseMessageAsync(CancellationToken cancellationToken)
+            {
+                switch (RequestMessage.MsgType)
+                {
+                    //以下是普通信息
+                    case RequestMsgType.Text:
+                    {
+                        var requestMessage = RequestMessage as RequestMessageText;
+
+                        ResponseMessage = await OnTextRequestAsync(requestMessage);           
+                    }
+                        break;
+                    default:
+                        ResponseMessage = await DefaultResponseMessageAsync(RequestMessage);
+                        break;
+                }
+            }
+
+            #region 接收消息方法
+            public virtual async Task<IWorkResponseMessageBase> DefaultResponseMessageAsync(IWorkRequestMessageBase requestMessage)
+            {
+                return await Task.Run(() => DefaultResponseMessage(requestMessage)).ConfigureAwait(false);
+            }
+
+            public virtual async Task<IWorkResponseMessageBase> OnTextRequestAsync(RequestMessageText requestMessage)
+            {
+                return await Task.Run(() => OnTextRequest(requestMessage)).ConfigureAwait(false);
+            }
+
+            #endregion
+        }
+}

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/MessageHandlers/WorkBotMessageHandler.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/MessageHandlers/WorkBotMessageHandler.cs
@@ -1,0 +1,162 @@
+/*----------------------------------------------------------------
+    Copyright (C) 2025 Senparc
+    
+    文件名：WorkBotMessageHandler.cs
+    文件功能描述：企业号智能机器人请求的集中处理方法
+    
+    
+    创建标识：Wang Qian - 20250825  
+----------------------------------------------------------------*/
+
+using System;
+using System.IO;
+using Senparc.NeuChar.Context;
+using Senparc.Weixin.Exceptions;
+using Senparc.NeuChar.MessageHandlers;
+using Senparc.Weixin.Work.Entities;
+using Senparc.Weixin.Work.Helpers;
+using Senparc.Weixin.Work.Tencent;
+using Senparc.NeuChar;
+using Senparc.NeuChar.ApiHandlers;
+using Senparc.Weixin.Work.AdvancedAPIs;
+using Senparc.Weixin.Work.Entities.Request.Event;
+using System.Xml.Linq;
+using Senparc.NeuChar.Entities;
+using Senparc.CO2NET.Helpers;
+
+namespace Senparc.Weixin.Work.MessageHandlers
+{
+    public interface IWorkBotMessageHandler : IMessageHandler<IWorkRequestMessageBase, IWorkResponseMessageBase>
+    {
+        /// <summary>
+        /// 原始加密信息
+        /// </summary>
+        BotEncryptPostData EncryptPostData { get; set; }
+        new IWorkRequestMessageBase RequestMessage { get; set; }
+        new IWorkResponseMessageBase ResponseMessage { get; set; }
+
+    }
+
+    public abstract partial class WorkBotMessageHandler<TMC>
+        : MessageHandler<TMC, IWorkRequestMessageBase, IWorkResponseMessageBase>, IWorkBotMessageHandler
+        where TMC : class, IMessageContext<IWorkRequestMessageBase, IWorkResponseMessageBase>, new()
+    {
+        private PostModel _postModel;
+
+        public BotEncryptPostData EncryptPostData { get; set; }
+
+        /// <summary>
+        /// 请求消息实体
+        /// </summary>
+        public new IWorkRequestMessageBase RequestMessage { get; set; }
+
+        /// <summary>
+        /// 响应消息实体
+        /// </summary>
+        public new IWorkResponseMessageBase ResponseMessage { get; set; }
+
+
+        /// <summary>
+        /// 从ResponseMessage转换而来的响应消息JSON字符串（未加密）
+        /// </summary>
+        public override string ResponseJsonStr
+        { 
+            get
+        {
+            if (ResponseMessage == null)
+            {
+                return null;
+            }
+            return BotEntityHelper.GetResponseMsgString(ResponseMessage as WorkResponseMessageBase);
+        } 
+        }
+
+        /// <summary>
+        /// 最终响应消息JSON字符串（已加密）
+        /// </summary>
+        public override string FinalResponseJsonStr
+        { 
+            get
+        {
+            if (ResponseJsonStr == null)
+            {
+                return null;
+            }
+            var timeStamp = SystemTime.Now.Ticks.ToString();
+                var nonce = SystemTime.Now.Ticks.ToString();
+
+                WXBizMsgCrypt msgCrype = new WXBizMsgCrypt(_postModel.Token, _postModel.EncodingAESKey, _postModel.CorpId);
+                string finalResponseJson = null;
+                msgCrype.EncryptJsonMsg(ResponseJsonStr, timeStamp, nonce, ref finalResponseJson);
+                return finalResponseJson;
+        } 
+        }
+
+
+        protected WorkBotMessageHandler(Stream inputStream, IEncryptPostModel postModel, int maxRecordCount = 0, bool onlyAllowEncryptMessage = false, IServiceProvider serviceProvider = null, bool useJson = true) : base(inputStream, postModel, maxRecordCount, onlyAllowEncryptMessage, serviceProvider, useJson)
+        {
+        }
+
+        public override string Init(string postDataJson, IEncryptPostModel postModel)
+        {
+            _postModel = postModel as PostModel ?? new PostModel();
+
+            //解密，获得明文字符串
+            string msgJson = null;
+            WXBizMsgCrypt msgCrype = new WXBizMsgCrypt(_postModel.Token, _postModel.EncodingAESKey, _postModel.CorpId);
+            var result = msgCrype.DecryptJsonMsg(_postModel.Msg_Signature, _postModel.Timestamp, _postModel.Nonce, postDataJson, ref msgJson);
+
+            if (result != 0)
+            {
+                throw new MessageHandlerException($"解密失败，错误码：{result}");
+            }
+            RequestMessage = BotEntityHelper.GetRequestEntity(msgJson);
+            RequestJsonStr = msgJson;
+            return msgJson;
+        }
+
+        /// <summary>
+        /// 根据当前的RequestMessage创建指定类型的ResponseMessage
+        /// </summary>
+        /// <typeparam name="TR">基于ResponseMessageBase的响应消息类型</typeparam>
+        /// <returns></returns>
+        public TR CreateResponseMessage<TR>() where TR : WorkResponseMessageBase
+        {
+            if (RequestMessage == null)
+            {
+                return null;
+            }
+
+            return RequestMessage.CreateResponseMessage<TR>();
+        }
+
+
+
+        [Obsolete("请使用异步方法 OnExecutingAsync()", true)]
+        public virtual void OnExecuting()
+        {
+            throw new MessageHandlerException("请使用异步方法 OnExecutingAsync()");
+        }
+
+        [Obsolete("请使用异步方法 OnExecutedAsync()", true)]
+        public virtual void OnExecuted()
+        {
+            throw new MessageHandlerException("请使用异步方法 OnExecutedAsync()");
+        }
+
+        /// <summary>
+        /// 默认返回消息（当任何OnXX消息没有被重写，都将自动返回此默认消息）
+        /// </summary>
+        public abstract IWorkResponseMessageBase DefaultResponseMessage(IWorkRequestMessageBase requestMessage);
+
+        #region 接收消息方法
+        /// <summary>
+        /// 文字类型请求
+        /// </summary>
+        public virtual IWorkResponseMessageBase OnTextRequest(RequestMessageText requestMessage)
+        {
+            return DefaultResponseMessage(requestMessage);
+        }
+        #endregion
+    }
+}

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/MessageHandlers/WorkBotMessageHandler.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/MessageHandlers/WorkBotMessageHandler.cs
@@ -83,7 +83,7 @@ namespace Senparc.Weixin.Work.MessageHandlers
                 return null;
             }
             var timeStamp = SystemTime.Now.Ticks.ToString();
-                var nonce = SystemTime.Now.Ticks.ToString();
+                var nonce = Guid.NewGuid().ToString("N");
 
                 //加解密库要求传 receiveid 参数，企业自建智能机器人的使用场景里，receiveid直接传空字符串即可
                 WXBizMsgCrypt msgCrype = new WXBizMsgCrypt(_postModel.Token, _postModel.EncodingAESKey, "");

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/MessageHandlers/WorkMessageHandler.cs
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/MessageHandlers/WorkMessageHandler.cs
@@ -139,7 +139,7 @@ namespace Senparc.Weixin.Work.MessageHandlers
                 }
 
                 var timeStamp = SystemTime.Now.Ticks.ToString();
-                var nonce = SystemTime.Now.Ticks.ToString();
+                var nonce = Guid.NewGuid().ToString("N");
 
                 WXBizMsgCrypt msgCrype = new WXBizMsgCrypt(_postModel.Token, _postModel.EncodingAESKey, _postModel.CorpId);
                 string finalResponseXml = null;

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Senparc.Weixin.Work.net8.csproj
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Senparc.Weixin.Work.net8.csproj
@@ -221,6 +221,8 @@
 		</PackageReleaseNotes>
 		<RepositoryUrl>https://github.com/JeffreySu/WeiXinMPSDK</RepositoryUrl>
 		<SignAssembly>False</SignAssembly>
+		<Configurations>Release;Debug</Configurations>
+		<Platforms>x86;AnyCPU</Platforms>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<OutputPath>..\..\BuildOutPut</OutputPath>
@@ -262,7 +264,7 @@
 		<Reference Include="System.Xml.Linq" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Senparc.NeuChar" Version="2.6.0-beta.1" />
+		<PackageReference Include="Senparc.NeuChar" Version="2.6.0-beta.2-test" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\Senparc.Weixin\Senparc.Weixin\Senparc.Weixin.net8.csproj" />


### PR DESCRIPTION
重构设置公共属性方法

实现智能机器人MessageHandler

加解密测试通过

MessageHandler测试未通过（Execute方法未通过)
在基类CheckMessageRepeat()中调用GetInsertMessagekey()函数时会抛空引用异常

目前未解决

注：NeuChar升级为了还没发布的测试版本，为NeuChar pr中的版本