### PR TITLE
修正版本号拼写错误

### DIFF
--- a/src/Senparc.WebSocket/src/Senparc.WebSocket/Senparc.WebSocket/Senparc.WebSocket.net10.csproj
+++ b/src/Senparc.WebSocket/src/Senparc.WebSocket/Senparc.WebSocket/Senparc.WebSocket.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
-    <Version>1.2.0-preivew.net.10</Version>
+    <Version>1.2.0-preview.10</Version>
     <AssemblyName>Senparc.WebSocket</AssemblyName>
     <RootNamespace>Senparc.WebSocket</RootNamespace>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>

--- a/src/Senparc.Weixin.All/Senparc.Weixin.All.net10.csproj
+++ b/src/Senparc.Weixin.All/Senparc.Weixin.All.net10.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2025.11.0-preivew.net.10</Version>
+    <Version>2025.11.0-preview.10</Version>
     <LangVersion>10.0</LangVersion>
     <AssemblyName>Senparc.Weixin.All</AssemblyName>
     <RootNamespace>Senparc.Weixin.All</RootNamespace>

--- a/src/Senparc.Weixin.AspNet/Senparc.Weixin.AspNet.net10.csproj
+++ b/src/Senparc.Weixin.AspNet/Senparc.Weixin.AspNet.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net10.0</TargetFrameworks>
-    <Version>1.6.0-preivew.net.10</Version>
+    <Version>1.6.0-preview.10</Version>
     <AssemblyName>Senparc.Weixin.AspNet</AssemblyName>
     <RootNamespace>Senparc.Weixin.AspNet</RootNamespace>
     <!--<OutputType>Library</OutputType>-->

--- a/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.CsRedis/Senparc.Weixin.Cache.CsRedis.net10.csproj
+++ b/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.CsRedis/Senparc.Weixin.Cache.CsRedis.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
-    <Version>1.3.0-preivew.net.10</Version>
+    <Version>1.3.0-preview.10</Version>
     <AssemblyName>Senparc.Weixin.Cache.CsRedis</AssemblyName>
     <RootNamespace>Senparc.Weixin.Cache.CsRedis</RootNamespace>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>

--- a/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Dapr/Senparc.Weixin.Cache.Dapr.net10.csproj
+++ b/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Dapr/Senparc.Weixin.Cache.Dapr.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
-    <Version>0.3.0-preivew.net.10</Version>
+    <Version>0.3.0-preview.10</Version>
     <AssemblyName>Senparc.Weixin.Cache.Dapr</AssemblyName>
     <RootNamespace>Senparc.Weixin.Cache.Dapr</RootNamespace>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>

--- a/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Memcached/Senparc.Weixin.Cache.Memcached.net10.csproj
+++ b/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Memcached/Senparc.Weixin.Cache.Memcached.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
-    <Version>2.19.0-preivew.net.10</Version>
+    <Version>2.19.0-preview.10</Version>
     <AssemblyName>Senparc.Weixin.Cache.Memcached</AssemblyName>
     <RootNamespace>Senparc.Weixin.Cache.Memcached</RootNamespace>
     <Description>

--- a/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Redis/Senparc.Weixin.Cache.Redis.net10.csproj
+++ b/src/Senparc.Weixin.Cache/Senparc.Weixin.Cache.Redis/Senparc.Weixin.Cache.Redis.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
-    <Version>2.21.0-preivew.net.10</Version>
+    <Version>2.21.0-preview.10</Version>
     <AssemblyName>Senparc.Weixin.Cache.Redis</AssemblyName>
     <RootNamespace>Senparc.Weixin.Cache.Redis</RootNamespace>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>

--- a/src/Senparc.Weixin.MP.Middleware/Senparc.Weixin.MP.Middleware.net10.csproj
+++ b/src/Senparc.Weixin.MP.Middleware/Senparc.Weixin.MP.Middleware.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
-    <Version>1.5.0-preivew.net.10</Version>
+    <Version>1.5.0-preview.10</Version>
     <AssemblyName>Senparc.Weixin.MP.Middleware</AssemblyName>
     <RootNamespace>Senparc.Weixin.MP.Middleware</RootNamespace>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>

--- a/src/Senparc.Weixin.MP.MvcExtension/Senparc.Weixin.MP.MvcExtension/Senparc.Weixin.MP.MvcExtension.net10.csproj
+++ b/src/Senparc.Weixin.MP.MvcExtension/Senparc.Weixin.MP.MvcExtension/Senparc.Weixin.MP.MvcExtension.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
-    <Version>7.17.0-preivew.net.10</Version>
+    <Version>7.17.0-preview.10</Version>
     <AssemblyName>Senparc.Weixin.MP.MvcExtension</AssemblyName>
     <RootNamespace>Senparc.Weixin.MP.MvcExtension</RootNamespace>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>

--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Senparc.Weixin.MP.net10.csproj
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/Senparc.Weixin.MP.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
-		<Version>16.24.0-preivew.net.10</Version>
+		<Version>16.24.0-preview.10</Version>
 		<AssemblyName>Senparc.Weixin.MP</AssemblyName>
 		<RootNamespace>Senparc.Weixin.MP</RootNamespace>
 		<GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>

--- a/src/Senparc.Weixin.Open/Senparc.Weixin.Open/Senparc.Weixin.Open.net10.csproj
+++ b/src/Senparc.Weixin.Open/Senparc.Weixin.Open/Senparc.Weixin.Open.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
-    <Version>4.23.0-preivew.net.10</Version>
+    <Version>4.23.0-preview.10</Version>
     <AssemblyName>Senparc.Weixin.Open</AssemblyName>
     <RootNamespace>Senparc.Weixin.Open</RootNamespace>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>

--- a/src/Senparc.Weixin.TenPay/Senparc.Weixin.TenPay/Senparc.Weixin.TenPay.net10.csproj
+++ b/src/Senparc.Weixin.TenPay/Senparc.Weixin.TenPay/Senparc.Weixin.TenPay.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
-    <Version>1.18.0-preivew.net.10</Version>
+    <Version>1.18.0-preview.10</Version>
     <AssemblyName>Senparc.Weixin.TenPay</AssemblyName>
     <RootNamespace>Senparc.Weixin.TenPay</RootNamespace>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>

--- a/src/Senparc.Weixin.TenPay/Senparc.Weixin.TenPayV3/Senparc.Weixin.TenPayV3.net10.csproj
+++ b/src/Senparc.Weixin.TenPay/Senparc.Weixin.TenPayV3/Senparc.Weixin.TenPayV3.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>2.3.0-preivew.net.10</Version>
+    <Version>2.3.0-preview.10</Version>
     <AssemblyName>Senparc.Weixin.TenPayV3</AssemblyName>
     <RootNamespace>Senparc.Weixin.TenPayV3</RootNamespace>
     <LangVersion>10.0</LangVersion>

--- a/src/Senparc.Weixin.Work.Middleware/Senparc.Weixin.Work.Middleware.net10.csproj
+++ b/src/Senparc.Weixin.Work.Middleware/Senparc.Weixin.Work.Middleware.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
-    <Version>1.5.0-preivew.net.10</Version>
+    <Version>1.5.0-preview.10</Version>
     <AssemblyName>Senparc.Weixin.Work.Middleware</AssemblyName>
     <RootNamespace>Senparc.Weixin.Work.Middleware</RootNamespace>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>

--- a/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Senparc.Weixin.Work.net10.csproj
+++ b/src/Senparc.Weixin.Work/Senparc.Weixin.Work/Senparc.Weixin.Work.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
-    <Version>3.29.0-preivew.net.10</Version>
+    <Version>3.29.0-preview.10</Version>
     <LangVersion>10.0</LangVersion>
     <AssemblyName>Senparc.Weixin.Work</AssemblyName>
     <RootNamespace>Senparc.Weixin.Work</RootNamespace>

--- a/src/Senparc.Weixin.WxOpen.Middleware/Senparc.Weixin.WxOpen.Middleware.net10.csproj
+++ b/src/Senparc.Weixin.WxOpen.Middleware/Senparc.Weixin.WxOpen.Middleware.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
-    <Version>1.5.0-preivew.net.10</Version>
+    <Version>1.5.0-preview.10</Version>
     <AssemblyName>Senparc.Weixin.WxOpen.Middleware</AssemblyName>
     <RootNamespace>Senparc.Weixin.WxOpen.Middleware</RootNamespace>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>

--- a/src/Senparc.Weixin.WxOpen/src/Senparc.Weixin.WxOpen/Senparc.Weixin.WxOpen/Senparc.Weixin.WxOpen.net10.csproj
+++ b/src/Senparc.Weixin.WxOpen/src/Senparc.Weixin.WxOpen/Senparc.Weixin.WxOpen/Senparc.Weixin.WxOpen.net10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
-    <Version>3.24.0-preivew.net.10</Version>
+    <Version>3.24.0-preview.10</Version>
     <LangVersion>10.0</LangVersion>
     <AssemblyName>Senparc.Weixin.WxOpen</AssemblyName>
     <RootNamespace>Senparc.Weixin.WxOpen</RootNamespace>

--- a/src/Senparc.Weixin/Senparc.Weixin/Senparc.Weixin.net10.csproj
+++ b/src/Senparc.Weixin/Senparc.Weixin/Senparc.Weixin.net10.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net10.0</TargetFrameworks>
     <!--<FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(Net35FrameworkPathOverride)</FrameworkPathOverride>-->
-    <Version>6.23.0-preivew.net.10</Version>
+    <Version>6.23.0-preview.10</Version>
     <LangVersion>10.0</LangVersion>
     <AssemblyName>Senparc.Weixin</AssemblyName>
     <RootNamespace>Senparc.Weixin</RootNamespace>


### PR DESCRIPTION
修正多个项目文件中的版本号拼写错误，将“preivew”更正为“preview”。涉及的项目文件包括 Senparc.WebSocket、Senparc.Weixin.All、Senparc.Weixin.AspNet、Senparc.Weixin.Cache.CsRedis、Senparc.Weixin.Cache.Dapr、Senparc.Weixin.Cache.Memcached、Senparc.Weixin.Cache.Redis、Senparc.Weixin.MP.Middleware、Senparc.Weixin.MP.MvcExtension、Senparc.Weixin.MP、Senparc.Weixin.Open、Senparc.Weixin.TenPay、Senparc.Weixin.TenPayV3、Senparc.Weixin.Work.Middleware、Senparc.Weixin.Work、Senparc.Weixin.WxOpen.Middleware、Senparc.Weixin.WxOpen 和 Senparc.Weixin。此更改确保了版本号的一致性和正确性，以便于版本管理和发布。