### PR TITLE
修复 GetStableAccessToken 方法中 force_refresh 参数硬编码问题

### DIFF
--- a/src/Senparc.Weixin.MP/Senparc.Weixin.MP/CommonAPIs/CommonApi.cs
+++ b/src/Senparc.Weixin.MP/Senparc.Weixin.MP/CommonAPIs/CommonApi.cs
@@ -131,7 +131,7 @@ namespace Senparc.Weixin.MP.CommonAPIs
                 grant_type= "client_credential",
                 appid= appid,
                 secret= secret,
-                force_refresh= false
+                force_refresh= force_refresh
             };
             AccessTokenResult result = CommonJsonSend.Send<AccessTokenResult>(null, url, data, CommonJsonSendType.POST);
             if (Config.ThrownWhenJsonResultFaild && result.errcode != ReturnCode.请求成功)
@@ -281,7 +281,7 @@ namespace Senparc.Weixin.MP.CommonAPIs
                 grant_type= "client_credential",
                 appid= appid,
                 secret= secret,
-                force_refresh= false
+                force_refresh= force_refresh
             };
 
             AccessTokenResult result = await CommonJsonSend.SendAsync<AccessTokenResult>(null, url, data, CommonJsonSendType.POST);


### PR DESCRIPTION
原先 `force_refresh` 参数被硬编码为 `false`，导致无法通过外部参数控制是否强制刷新 AccessToken。此更改允许根据方法传入的 `force_refresh` 参数来决定是否刷新。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change that only affects callers who set `force_refresh=true`, which will now actually trigger token refresh and invalidate the previous token as intended.
> 
> **Overview**
> **Bug fix:** `CommonApi.GetStableAccessToken` and `GetStableAccessTokenAsync` now pass the caller-provided `force_refresh` value in the POST body to `/cgi-bin/stable_token` instead of always sending `false`.
> 
> This enables external code to correctly request a forced refresh of the stable `access_token` when needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55c3c1bdfcf97c6fe2ca05f7fd8572ca65defb6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->